### PR TITLE
fix: imported the wrong code example

### DIFF
--- a/docs/sdk/1-workshop/05-ctype.md
+++ b/docs/sdk/1-workshop/05-ctype.md
@@ -56,7 +56,7 @@ Create a new file `ctype.js`
 Copy the following to create a `CType` from a schema:
 
 <CodeBlock className="language-ts">
-  {Example1}
+  {Example2}
 </CodeBlock>
 
 Once you have constructed the schema, pass the attester, attestersFullDid, keystore and ctype.
@@ -66,7 +66,7 @@ Creating a new file `storedCtype.js`
 Copy the following to store the `CType` on-chain, an account must have the require amount to pay the Angel's fee and deposit:
 
 <CodeBlock className="language-ts">
-  {Example2}
+  {Example3}
 </CodeBlock>
 
 Create a new file `ctype.json` and store the ctype.


### PR DESCRIPTION
## fixes NO TICKET

Fixes the ctype export examples in the ctype workshop

## How to test:
Please provide a brief step-by-step instruction.
If necessary provide information about dependencies (specific configuration, branches, database dumps, etc.)

- Step 1
- Step 2
- etc.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
