### PR TITLE
Test docs agains new sdk rc

### DIFF
--- a/.github/ISSUE_TEMPLATE/sdk-incompatible-with-docs.md
+++ b/.github/ISSUE_TEMPLATE/sdk-incompatible-with-docs.md
@@ -1,0 +1,6 @@
+---
+## Incompatible SDK detected
+
+---
+
+- [ ] Check if any docs needs to be updated, and if needed do so

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -61,7 +61,6 @@ jobs:
         working-directory: code_examples/core_features
         run: |
           yarn install
-
       - name: Run tests
         timeout-minutes: 60
         working-directory: code_examples/core_features
@@ -75,7 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ workshop, core_features ]
     if: success()
-
     steps:
       - uses: actions/checkout@v1
       - name: Get current package version
@@ -124,7 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ workshop, core_features ]
     if: failure()
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -1,0 +1,147 @@
+name: test-docs-examples-2
+
+on:
+  repository_dispatch:
+    types: [ sdk-update ]
+
+jobs:
+  workshop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Get current package version
+        working-directory: code_examples/workshop
+        id: kiltprotocol_sdk
+        run: echo "::set-output name=current_tag::$(grep kiltprotocol/sdk-js package.json | awk -F \" '{print $4}')"
+      - uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: '@kiltprotocol/sdk-js": "${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
+          replace: '@kiltprotocol/sdk-js": "${{ github.event.inputs.client_payload.latestTag }}'
+          include: "code_examples/**"
+          exclude: "**/*.lock"
+          regex: true
+      - name: Test style conventions
+        working-directory: code_examples/workshop
+        run: |
+          yarn install
+
+      - name: Run tests
+        timeout-minutes: 60
+        working-directory: code_examples/workshop
+        env:
+          NODE_OPTIONS: --unhandled-rejections=strict
+          FAUCET_SEED: ${{ secrets.PEREGRINE_FAUCET_SEED }}
+        run: |
+          yarn install
+          yarn run ts-node test.ts
+
+  core_features:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get current package version
+        working-directory: code_examples/core_features
+        id: kiltprotocol_sdk
+        run: echo "::set-output name=current_tag::$(grep kiltprotocol/sdk-js package.json | awk -F \" '{print $4}')"
+      - uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: '@kiltprotocol/sdk-js": "${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
+          replace: '@kiltprotocol/sdk-js": "${{ github.event.inputs.client_payload.latestTag }}'
+          include: "code_examples/**"
+          exclude: "**/*.lock"
+          regex: true
+      - name: Test style conventions
+        working-directory: code_examples/core_features
+        run: |
+          yarn install
+
+      - name: Run tests
+        timeout-minutes: 60
+        working-directory: code_examples/core_features
+        env:
+          NODE_OPTIONS: --unhandled-rejections=strict
+          FAUCET_SEED: ${{ secrets.PEREGRINE_FAUCET_SEED }}
+        run: |
+          yarn run ts-node run_core_features.ts
+
+ create_pull_request:
+    runs-on: ubuntu-latest
+    needs: [ workshop, core_features ]
+    if: success()
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get current package version
+        working-directory: code_examples/core_features
+        id: kiltprotocol_sdk
+        run: echo "::set-output name=current_tag::$(grep kiltprotocol/sdk-js package.json | awk -F \" '{print $4}')"
+      - uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: '${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
+          replace: '${{ github.event.client_payload.latestTag }}'
+          include: "docs/develop/03_workshop/**"
+          regex: true
+      - uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: '@kiltprotocol/sdk-js": "${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
+          replace: '@kiltprotocol/sdk-js": "${{ github.event.client_payload.latestTag }}'
+          include: "code_examples/**"
+          exclude: "**/*.lock"
+          regex: true
+      - name: Regenerate yarn lock
+        working-directory: code_examples/core_features
+        run: |
+          yarn install
+          yarn lint
+      - name: Regenerate yarn lock
+        working-directory: code_examples/workshop
+        run: |
+          yarn install
+          yarn lint
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          base: develop
+          delete-branch: true
+          title: '[Chore] Latest sdk is compatible with docs'
+          body: |
+            Update sdk in the docs with the latest version ${{ github.event.client_payload.latestTag }}
+            - Beware ~ CI-generated PR
+          labels: |
+            sdk
+          draft: false
+          add-paths: |
+            *package.json
+            *yarn.lock
+            *.md
+ create_issue:
+    runs-on: ubuntu-latest
+    needs: [ workshop, core_features ]
+    if: failure()
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate issue
+        run: |
+          cd .github/ISSUE_TEMPLATE
+          echo "[Either workshop or core_features test workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) using the latest sdk ${{ github.event.client_payload.latestTag }} on docs has failed.Please fix!" >> sdk-incompatible-with-docs.md
+      - name: Create issue
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: new sdk ${{ github.event.client_payload.latestTag }} is incompatible with docs examples
+          repository: KILTProtocol/ticket
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          content-filepath: .github/ISSUE_TEMPLATE/sdk-incompatible-with-docs.md
+          labels: |
+            :memo:  documentation
+            📚+release
+            🧰 sdk

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -30,7 +30,6 @@ jobs:
         working-directory: code_examples/workshop
         run: |
           yarn install
-
       - name: Run tests
         timeout-minutes: 60
         working-directory: code_examples/workshop
@@ -38,7 +37,6 @@ jobs:
           NODE_OPTIONS: --unhandled-rejections=strict
           FAUCET_SEED: ${{ secrets.PEREGRINE_FAUCET_SEED }}
         run: |
-          yarn install
           yarn run ts-node test.ts
 
   core_features:
@@ -70,7 +68,7 @@ jobs:
         run: |
           yarn run ts-node run_core_features.ts
 
- create_pull_request:
+  create_pull_request:
     runs-on: ubuntu-latest
     needs: [ workshop, core_features ]
     if: success()
@@ -109,7 +107,7 @@ jobs:
           delete-branch: true
           title: '[Chore] Update SDK version to latest'
           body: |
-            Update sdk  version in the docs to the latest version ${{ github.event.client_payload.latestTag }} since it passes compatibility test
+            Update SDK  version in the docs to the latest version ${{ github.event.client_payload.latestTag }} since it passes compatibility test
             - Beware ~ CI-generated PR
           labels: |
             sdk
@@ -118,7 +116,7 @@ jobs:
             *package.json
             *yarn.lock
             *.md
- create_issue:
+  create_issue:
     runs-on: ubuntu-latest
     needs: [ workshop, core_features ]
     if: failure()

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: '@kiltprotocol/sdk-js": "${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
-          replace: '@kiltprotocol/sdk-js": "${{ github.event.inputs.client_payload.latestTag }}'
+          replace: '@kiltprotocol/sdk-js": "${{ github.event.client_payload.latestTag }}'
           include: "code_examples/**"
           exclude: "**/*.lock"
           regex: true
@@ -51,7 +51,7 @@ jobs:
       - uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: '@kiltprotocol/sdk-js": "${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
-          replace: '@kiltprotocol/sdk-js": "${{ github.event.inputs.client_payload.latestTag }}'
+          replace: '@kiltprotocol/sdk-js": "${{ github.event.client_payload.latestTag }}'
           include: "code_examples/**"
           exclude: "**/*.lock"
           regex: true
@@ -137,4 +137,6 @@ jobs:
             :memo:  documentation
             📚+release
             🧰 sdk
+            🚚+high
+            
             

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -99,21 +99,19 @@ jobs:
         working-directory: code_examples/core_features
         run: |
           yarn install
-          yarn lint
       - name: Regenerate yarn lock
         working-directory: code_examples/workshop
         run: |
           yarn install
-          yarn lint
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           base: develop
           delete-branch: true
-          title: '[Chore] Latest sdk is compatible with docs'
+          title: '[Chore] Update SDK version to latest'
           body: |
-            Update sdk in the docs with the latest version ${{ github.event.client_payload.latestTag }}
+            Update sdk  version in the docs to the latest version ${{ github.event.client_payload.latestTag }} since it passes compatibility test
             - Beware ~ CI-generated PR
           labels: |
             sdk
@@ -132,8 +130,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Generate issue
         run: |
-          cd .github/ISSUE_TEMPLATE
-          echo "[Either workshop or core_features test workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) using the latest sdk ${{ github.event.client_payload.latestTag }} on docs has failed.Please fix!" >> sdk-incompatible-with-docs.md
+          echo "[Either workshop or core_features test workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) using the latest sdk ${{ github.event.client_payload.latestTag }} on docs has failed.Please fix!" >> .github/ISSUE_TEMPLATE/sdk-incompatible-with-docs.md
       - name: Create issue
         uses: peter-evans/create-issue-from-file@v3
         with:
@@ -145,3 +142,4 @@ jobs:
             :memo:  documentation
             📚+release
             🧰 sdk
+            


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1908
Whenever a new tag is add for a release candidate this jobs replaces sdk version on the docs and test it. If sucessful opens PR to update the docs to the latest SDK on failure opens an issue ticket. This should be triggered by `repository_dispatch` fron sdk branch
[Expected Issue](https://github.com/ggera/ticket/issues/5)
[Expected PR](https://github.com/ggera/docs/pull/10) 
## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
