### PR TITLE
fix: unsafe external for docker

### DIFF
--- a/docs/participate/collator.md
+++ b/docs/participate/collator.md
@@ -62,6 +62,7 @@ Exposing the RPC endpoint can be done using the following parameters:
 --rpc-port=9933
 --rpc-cors=all
 --rpc-methods=unsafe
+--unsafe-rpc-external // ONLY for docker based setups
 ```
 
 Exposing the RPC endpoint of a collator does not imply that it becomes accessible via the PolkadotJS Apps interface, because this requires a Websocket to connect to the node.
@@ -209,7 +210,7 @@ It is recommended to change them throughout sessions.
 :::warning
 
 Make sure that no unauthorised party is able to access the RPC endpoint of the collator.
-Use SSH forwarding for the RPC port when needing to perform some RPC operations on the node with 
+Use SSH forwarding for the RPC port when needing to perform some RPC operations on the node with
 ```
 ssh -L 127.0.0.1:9944:127.0.0.1:9944 <user>@<server>
 ```
@@ -484,7 +485,7 @@ For **Peregrine**, the parachain bootnodes are:
 --bootnodes=/dns4/eyrie-1.kilt.io/tcp/30371/p2p/12D3KooWALJtiCZzcUPVsCa5f5egGfQyFhPY67kKosDw95bJqK7M \
 --bootnodes=/dns4/eyrie-2.kilt.io/tcp/30372/p2p/12D3KooWCRgcGtFRsvqxqgysiR6Ah9SAzUNkM12Ef9sy59ZEspSQ
 ```
-  
+
 </TabItem>
 </Tabs>
 
@@ -608,7 +609,7 @@ Its address should be listed when querying `session > validators()`.
 ### Rewards have stopped
 
 If you have stopped to receive rewards, either
-1. You were kicked out of the top collator candidate list because your total stake is too low. 
+1. You were kicked out of the top collator candidate list because your total stake is too low.
 See [above](#how-to-check-your-position) for the necessary steps to retrieve the least staked candidate address in that list.
 You can query their stake by going to `Developer -> Chain State` calling `parachainStaking -> candidatePool(address) -> +`.
 2. You have connectivity issues, see [above](#troubleshooting) for resolution tips

--- a/docs/participate/collator/1b_start_node_docker.mdx
+++ b/docs/participate/collator/1b_start_node_docker.mdx
@@ -20,6 +20,7 @@ Please select your target network:
     --rpc-port=9933 \
     --rpc-cors=all \
     --rpc-methods=unsafe \
+    --unsafe-rpc-external \
     --name="name of collator" \
     --execution=wasm \
     --listen-addr=/ip4/0.0.0.0/tcp/30336 \
@@ -31,10 +32,10 @@ Please select your target network:
     --listen-addr=/ip4/0.0.0.0/tcp/30333 \
     --base-path=/data/relay \
     --execution=wasm
-  ``` 
+  ```
   </TabItem>
 
-  <TabItem value="Peregrine" label="Peregrine" attributes={{'data-value': 'magenta'}}>   
+  <TabItem value="Peregrine" label="Peregrine" attributes={{'data-value': 'magenta'}}>
 
   To start the **Peregrine** collator container, run:
   ```bash=
@@ -45,6 +46,7 @@ Please select your target network:
     --rpc-port=9933 \
     --rpc-cors=all \
     --rpc-methods=unsafe \
+    --unsafe-rpc-external \
     --name="name of collator" \
     --execution=wasm \
     --listen-addr=/ip4/0.0.0.0/tcp/30336 \
@@ -56,7 +58,7 @@ Please select your target network:
     --listen-addr=/ip4/0.0.0.0/tcp/30333 \
     --base-path=/data/relay \
     --execution=wasm
-  ``` 
+  ```
 
   </TabItem>
   </Tabs>


### PR DESCRIPTION
## fixes KILTprotocol/docs/issues/38

The container needs to expose it externally so that the port can get mapped to the host port 

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
