### PR TITLE
chore: update docs for SDK v0.28.0

### DIFF
--- a/code_examples/core_features/claiming/01_create_ctype.ts
+++ b/code_examples/core_features/claiming/01_create_ctype.ts
@@ -12,7 +12,7 @@ export async function createDriversLicenseCType(
   // Create a new CType definition.
   const ctype = Kilt.CType.fromSchema({
     $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-    title: `Drivers License by ${creatorDid.did}`,
+    title: `Drivers License by ${creatorDid.uri}`,
     properties: {
       name: {
         type: 'string'

--- a/code_examples/core_features/claiming/02_request_attestation.ts
+++ b/code_examples/core_features/claiming/02_request_attestation.ts
@@ -13,7 +13,7 @@ export async function requestAttestation(
       age: 29,
       id: '123456789987654321'
     },
-    claimer.did
+    claimer.uri
   )
   // The attestation request must be signed by the claimer to provide non-repudiation.
   const requestForAttestation = Kilt.RequestForAttestation.fromClaim(claim)

--- a/code_examples/core_features/claiming/03_create_attestation.ts
+++ b/code_examples/core_features/claiming/03_create_attestation.ts
@@ -14,7 +14,7 @@ export async function createAttestation(
   // using the provided attester's full DID.
   const attestation = await Kilt.Attestation.fromRequestAndDid(
     requestForAttestation,
-    attester.did
+    attester.uri
   )
   const attestationTx = await attestation
     .getStoreTx()

--- a/code_examples/core_features/did/01_light_did_simple.ts
+++ b/code_examples/core_features/did/01_light_did_simple.ts
@@ -18,7 +18,7 @@ export async function createSimpleLightDid(
       type: Kilt.VerificationKeyType.Ed25519
     }
   })
-  console.log(lightDID.did)
+  console.log(lightDID.uri)
 
   return lightDID
 }

--- a/code_examples/core_features/did/02_light_did_complete.ts
+++ b/code_examples/core_features/did/02_light_did_complete.ts
@@ -38,7 +38,7 @@ export async function createCompleteLightDid(
     },
     serviceEndpoints
   })
-  console.log(lightDID.did)
+  console.log(lightDID.uri)
 
   return lightDID
 }

--- a/code_examples/core_features/did/04_full_did_simple.ts
+++ b/code_examples/core_features/did/04_full_did_simple.ts
@@ -25,15 +25,11 @@ export async function createSimpleFullDid(
   const fullDid = await new Kilt.Did.FullDidCreationBuilder(api, {
     publicKey: authenticationKeyPublicDetails.publicKey,
     type: Kilt.VerificationKeyType.Ed25519
-  }).consumeWithHandler(
-    keystore,
-    submitterAccount.address,
-    async (creationTx) => {
-      await Kilt.BlockchainUtils.signAndSubmitTx(creationTx, submitterAccount, {
-        resolveOn
-      })
-    }
-  )
+  }).buildAndSubmit(keystore, submitterAccount.address, async (creationTx) => {
+    await Kilt.BlockchainUtils.signAndSubmitTx(creationTx, submitterAccount, {
+      resolveOn
+    })
+  })
 
   if (!fullDid) {
     throw 'Could not find the DID just created.'

--- a/code_examples/core_features/did/05_full_did_complete.ts
+++ b/code_examples/core_features/did/05_full_did_complete.ts
@@ -63,19 +63,11 @@ export async function createCompleteFullDid(
       types: ['service-type'],
       urls: ['https://www.example.com']
     })
-    .consumeWithHandler(
-      keystore,
-      submitterAccount.address,
-      async (creationTx) => {
-        await Kilt.BlockchainUtils.signAndSubmitTx(
-          creationTx,
-          submitterAccount,
-          {
-            resolveOn
-          }
-        )
-      }
-    )
+    .buildAndSubmit(keystore, submitterAccount.address, async (creationTx) => {
+      await Kilt.BlockchainUtils.signAndSubmitTx(creationTx, submitterAccount, {
+        resolveOn
+      })
+    })
 
   if (!fullDid) {
     throw 'Could not find the DID just created.'

--- a/code_examples/core_features/did/06_full_did_update.ts
+++ b/code_examples/core_features/did/06_full_did_update.ts
@@ -30,7 +30,7 @@ export async function updateFullDid(
       type: Kilt.VerificationKeyType.Ed25519
     })
     .removeServiceEndpoint('my-service')
-    .consume(keystore, submitterAccount.address)
+    .build(keystore, submitterAccount.address)
 
   // Submit the DID update tx to the KILT blockchain after signing it with the authorized KILT account.
   await Kilt.BlockchainUtils.signAndSubmitTx(
@@ -43,11 +43,11 @@ export async function updateFullDid(
 
   // Get the updated DID Doc
   const updatedDidDetails = await Kilt.Did.FullDidDetails.fromChainInfo(
-    fullDid.identifier
+    fullDid.uri
   )
 
   if (!updatedDidDetails) {
-    throw `Could not find the updated DID ${fullDid.did}`
+    throw `Could not find the updated DID ${fullDid.uri}`
   }
   return updatedDidDetails
 }

--- a/code_examples/core_features/did/07_full_did_batch.ts
+++ b/code_examples/core_features/did/07_full_did_batch.ts
@@ -39,7 +39,7 @@ export async function batchCTypeCreationExtrinsics(
   // Create the DID-signed batch
   const batch = await new Kilt.Did.DidBatchBuilder(api, fullDid)
     .addMultipleExtrinsics([ctype1CreationTx, ctype2CreationTx])
-    .consume(keystore, submitterAccount.address)
+    .build(keystore, submitterAccount.address)
 
   // The authorized account submits the batch to the chain
   await Kilt.BlockchainUtils.signAndSubmitTx(batch, submitterAccount, {

--- a/code_examples/core_features/did/08_did_signature.ts
+++ b/code_examples/core_features/did/08_did_signature.ts
@@ -17,12 +17,11 @@ export async function generateAndVerifyDidAuthenticationSignature(
   console.log(JSON.stringify(signature, null, 2))
 
   // Verify the validity of the signature using the DID's authentication public key.
-  const signatureVerificationResult =
-    await Kilt.Did.DidUtils.verifyDidSignature({
-      message: payload,
-      signature,
-      expectedVerificationMethod: Kilt.KeyRelationship.authentication
-    })
+  const signatureVerificationResult = await Kilt.Did.verifyDidSignature({
+    message: payload,
+    signature,
+    expectedVerificationMethod: Kilt.KeyRelationship.authentication
+  })
 
   if (!signatureVerificationResult.verified) {
     throw `Signature failed to verify. Reason: ${signatureVerificationResult.reason}`

--- a/code_examples/core_features/did/09_full_did_delete.ts
+++ b/code_examples/core_features/did/09_full_did_delete.ts
@@ -11,10 +11,10 @@ export async function deleteFullDid(
 ): Promise<void> {
   // Create a DID deletion operation. We specify the number of endpoints currently stored under the DID because
   // of the upper computation limit required by the blockchain runtime.
-  const endpointsCountForDid = await Kilt.Did.DidChain.queryEndpointsCounts(
+  const endpointsCountForDid = await Kilt.Did.Chain.queryEndpointsCounts(
     fullDid.identifier
   )
-  const didDeletionExtrinsic = await Kilt.Did.DidChain.getDeleteDidExtrinsic(
+  const didDeletionExtrinsic = await Kilt.Did.Chain.getDeleteDidExtrinsic(
     endpointsCountForDid
   )
 

--- a/code_examples/core_features/did/10_full_did_deposit_reclaim.ts
+++ b/code_examples/core_features/did/10_full_did_deposit_reclaim.ts
@@ -4,21 +4,20 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function reclaimFullDidDeposit(
   depositPayerAccount: KeyringPair,
-  didIdentifier: Kilt.IDidIdentifier,
+  didIdentifier: Kilt.DidIdentifier,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.BlockchainUtils
     .IS_FINALIZED
 ): Promise<void> {
   // Generate the submittable extrinsic to claim the deposit back.
   // It includes the DID identifier for which the deposit needs to be returned
   // and the count of service endpoints to provide an upper bound to the computation of the extrinsic execution.
-  const endpointsCountForDid = await Kilt.Did.DidChain.queryEndpointsCounts(
+  const endpointsCountForDid = await Kilt.Did.Chain.queryEndpointsCounts(
     didIdentifier
   )
-  const depositClaimExtrinsic =
-    await Kilt.Did.DidChain.getReclaimDepositExtrinsic(
-      didIdentifier,
-      endpointsCountForDid
-    )
+  const depositClaimExtrinsic = await Kilt.Did.Chain.getReclaimDepositExtrinsic(
+    didIdentifier,
+    endpointsCountForDid
+  )
 
   // The submission will fail if `depositPayerAccount` is not the owner of the deposit associated with the given DID identifier.
   await Kilt.BlockchainUtils.signAndSubmitTx(

--- a/code_examples/core_features/getting_started/04_fetch_did.ts
+++ b/code_examples/core_features/getting_started/04_fetch_did.ts
@@ -1,6 +1,6 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
-export async function main(): Promise<string | null> {
+export async function main(): Promise<Kilt.DidUri | null> {
   const johnDoeDid = await Kilt.Did.Web3Names.queryDidForWeb3Name('john_doe')
   if (!johnDoeDid) {
     console.log(`john_doe doesn't exist`)

--- a/code_examples/core_features/getting_started/05_fetch_endpoints.ts
+++ b/code_examples/core_features/getting_started/05_fetch_endpoints.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function main(
-  johnDoeDid: Kilt.IDidDetails['did']
+  johnDoeDid: Kilt.IDidDetails['uri']
 ): Promise<Kilt.DidServiceEndpoint[]> {
   const johnDoeDidDocument = await Kilt.Did.DidResolver.resolveDoc(johnDoeDid)
   console.log(`John Doe's DID Document:`)

--- a/code_examples/core_features/linking/01_did_link.ts
+++ b/code_examples/core_features/linking/01_did_link.ts
@@ -20,11 +20,14 @@ export async function linkAccountToDid(
 
   // Authorizing the extrinsic with the full DID and including a signature of the linked account
   // results in the provided account being linked to the DID authorizing the operation.
-  const accountLinkingTx = await Kilt.Did.AccountLinks.authorizeLinkWithAccount(
-    linkedAccount.address,
-    did.identifier,
-    linkingAccountSignatureGeneration
-  ).then((tx) => did.authorizeExtrinsic(tx, keystore, submitterAccount.address))
+  const accountLinkingTx =
+    await Kilt.Did.AccountLinks.getAuthorizeLinkWithAccountExtrinsic(
+      linkedAccount.address,
+      did.identifier,
+      linkingAccountSignatureGeneration
+    ).then((tx) =>
+      did.authorizeExtrinsic(tx, keystore, submitterAccount.address)
+    )
 
   await Kilt.BlockchainUtils.signAndSubmitTx(
     accountLinkingTx,

--- a/code_examples/core_features/linking/02_account_link.ts
+++ b/code_examples/core_features/linking/02_account_link.ts
@@ -12,7 +12,7 @@ export async function linkDidToAccount(
   // Authorizing the extrinsic with the full DID and submitting it with the provided account
   // results in the submitter's account being linked to the DID authorizing the operation.
   const accountLinkingTx =
-    await Kilt.Did.AccountLinks.getAssociateSenderTx().then((tx) =>
+    await Kilt.Did.AccountLinks.getAssociateSenderExtrinsic().then((tx) =>
       did.authorizeExtrinsic(tx, keystore, submitterAccount.address)
     )
 

--- a/code_examples/core_features/linking/05_did_unlink.ts
+++ b/code_examples/core_features/linking/05_did_unlink.ts
@@ -11,9 +11,12 @@ export async function unlinkAccountFromDid(
     .IS_FINALIZED
 ): Promise<void> {
   // The DID owner removes the link between itself and the specified account.
-  const accountUnlinkTx = await Kilt.Did.AccountLinks.getLinkRemovalByDidTx(
-    linkedAccountAddress
-  ).then((tx) => did.authorizeExtrinsic(tx, keystore, submitterAccount.address))
+  const accountUnlinkTx =
+    await Kilt.Did.AccountLinks.getLinkRemovalByDidExtrinsic(
+      linkedAccountAddress
+    ).then((tx) =>
+      did.authorizeExtrinsic(tx, keystore, submitterAccount.address)
+    )
 
   await Kilt.BlockchainUtils.signAndSubmitTx(
     accountUnlinkTx,

--- a/code_examples/core_features/linking/index.ts
+++ b/code_examples/core_features/linking/index.ts
@@ -56,7 +56,7 @@ export async function runAll(
   console.log('3 linking) Query web3name for link account with SDK')
   let web3Name = await queryAccountWithSdk(linkAccount.address)
   if (!web3Name) {
-    throw `The DID "${fullDid.did}" is assumed to have a linked web3name, which it does not.`
+    throw `The DID "${fullDid.uri}" is assumed to have a linked web3name, which it does not.`
   }
   console.log('4 linking) Query web3name for submitter account without SDK')
   web3Name = await queryAccountWithoutSdk(api, submitterAccount.address)

--- a/code_examples/core_features/package.json
+++ b/code_examples/core_features/package.json
@@ -10,7 +10,7 @@
     "test": "ts-node run_core_features.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.27.0",
+    "@kiltprotocol/sdk-js": "0.28.0-rc.1",
     "axios": "^0.27.2",
     "dotenv": "^16.0.0"
   },

--- a/code_examples/core_features/package.json
+++ b/code_examples/core_features/package.json
@@ -10,7 +10,7 @@
     "test": "ts-node run_core_features.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.28.0-rc.1",
+    "@kiltprotocol/sdk-js": "0.28.0-rc.2",
     "axios": "^0.27.2",
     "dotenv": "^16.0.0"
   },

--- a/code_examples/core_features/package.json
+++ b/code_examples/core_features/package.json
@@ -10,7 +10,7 @@
     "test": "ts-node run_core_features.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.28.0-rc.2",
+    "@kiltprotocol/sdk-js": "0.28.0",
     "axios": "^0.27.2",
     "dotenv": "^16.0.0"
   },

--- a/code_examples/core_features/web3names/02_query_did_name.ts
+++ b/code_examples/core_features/web3names/02_query_did_name.ts
@@ -4,7 +4,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function verifyNameAndDidEquality(
   web3Name: Kilt.Did.Web3Names.Web3Name,
-  did: Kilt.IDidDetails['did']
+  did: Kilt.IDidDetails['uri']
 ): Promise<void> {
   console.log(
     `Querying the blockchain for the web3name "${web3Name}" and the DID "${did}"...`

--- a/code_examples/core_features/web3names/03_query_name_credentials.ts
+++ b/code_examples/core_features/web3names/03_query_name_credentials.ts
@@ -95,7 +95,7 @@ export async function queryPublishedCredentials(
 
       // Verify that the credential refers to the intended subject
       if (
-        !Kilt.Did.DidUtils.isSameSubject(credential.claim.owner, didForWeb3Name)
+        !Kilt.Did.Utils.isSameSubject(credential.claim.owner, didForWeb3Name)
       ) {
         throw 'One of the credentials refers to a different subject than expected.'
       }

--- a/code_examples/core_features/web3names/index.ts
+++ b/code_examples/core_features/web3names/index.ts
@@ -40,7 +40,7 @@ export async function runAll(
     resolveOn
   )
   console.log('2 w3n) Verify web3name owner and DID web3name')
-  await verifyNameAndDidEquality(randomWeb3Name, fullDid.did)
+  await verifyNameAndDidEquality(randomWeb3Name, fullDid.uri)
   console.log('3 w3n) Query credentials for "john_doe" web3name')
   try {
     await queryPublishedCredentials('john_doe')

--- a/code_examples/core_features/yarn.lock
+++ b/code_examples/core_features/yarn.lock
@@ -71,14 +71,14 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kiltprotocol/chain-helpers@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.1.tgz#50697bda019a6f1e3ab54369f5905fa5e04da4fb"
-  integrity sha512-iECkDmaYVk/dSIATz1KoonEBNJMrin3Rh0dHJMi0GDLbKxE031f4agHry+0x4u9yI+yGxCmte+bSRcsaIdtYVQ==
+"@kiltprotocol/chain-helpers@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.2.tgz#0386385cde72c64ce5b59780d29e655e2a2380ad"
+  integrity sha512-1+G75zENLnH/YNaIBbaJmsaxALZ4YUwCOMKEBrXNd4tHKBLwz9U+eysBopm4trchqDZqy1lUwnuW/40eT7uOCA==
   dependencies:
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -86,25 +86,25 @@
     "@polkadot/util" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/config@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.1.tgz#cfc0043a670119f48a6b7bd072625a888bc6dba3"
-  integrity sha512-tTeumsLt1inoHAOJuZTlzrtHg5nt3M78DkIKotoZSRxB+v5DGYbwrc6oF71R5/b5EdjhoxRWJbnft4Im2aA8lw==
+"@kiltprotocol/config@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.2.tgz#7c44a514e2baaf3362356e758461c51ccb5519d6"
+  integrity sha512-/fd2DY9C7K3vUJd1FQgFYfwU+UoyEM212Kak3uSwc0notkzv2tmL9lMXRcDMMwYf11mZIgmTGR/EZwC1txerRA==
   dependencies:
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.1.tgz#9c05d109e16ba5f29c07702d2ba08cabd85671af"
-  integrity sha512-JdcMZ3GpdUdu/vQKQGT0CQsztn97lTwKz7zgJfkil/6lw4hO6TONk6VkFw2F2CkwyhoKsQ1xbrj8+SyQ0Y0swA==
+"@kiltprotocol/core@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.2.tgz#4791e8d3440ad27e72502f189a86a2af9d96e23e"
+  integrity sha512-CHrgiW+bZ8Lxw/FLBdPyuWoQfXxiQzshR4N2YlePwsgHg1dkC4ypjZ8nnu0GRGH2ZMZhZHG92ctndHsDfpFSZw==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -115,15 +115,15 @@
     tweetnacl "^1.0.3"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/did@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.1.tgz#2b989bb959ba9b758d828d9427792743dc91c467"
-  integrity sha512-SrySBOJeMjLe4l1Cy6s8GUyOwOV6QYgnO1aY2t5cKSzVScWMu22Pm1/h/aDaNqLUaFKWesVZDgbPaoPan4IBHg==
+"@kiltprotocol/did@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.2.tgz#d6639d785705071ff105b065c4d2fe707293997d"
+  integrity sha512-9C/r7TlNmmsk8hBLpsltHpJtIcnkgS2xMlUAlDzsiOcXSlEfW5z4lLFdrVV2M0hz9Ypf91RI8h/+QEvGSqgdWg==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -132,35 +132,35 @@
     "@polkadot/util-crypto" "^9.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.1.tgz#2f9833b93c2bea37663d1bff43cfcec341d7175c"
-  integrity sha512-Q51c3W7VPYP+9ziv0EQtxF5QiKT+yKGAEN3kMBJIZnv6QK6HBMAij6625Up+9WgfI8PCWai5VOi1PScVXR3rnA==
+"@kiltprotocol/messaging@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.2.tgz#c86ce6160ea2a263405909e9e5c820022940c65a"
+  integrity sha512-6dfkJBDi1fZE7FNxU3FJY9l/yFhgR3xUxsASwdS9+rhbN0R0lkyQhJdBkWc+TTBNuK3gqAgGnM4lz+HvlwlaHg==
   dependencies:
-    "@kiltprotocol/core" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/core" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/util" "^9.0.0"
 
-"@kiltprotocol/sdk-js@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.1.tgz#2f9292626510bc2e53c4271c6a37f0c02379b10e"
-  integrity sha512-GCTCapgnfEDc1fMWMwQdCQPPcFEqWIp4cbJdimS1UgEqQ1cIU9WiOQ/jbudkZ1ygqdiwZkzdPGSoHl/A3n2CTQ==
+"@kiltprotocol/sdk-js@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.2.tgz#8b07326f4f958e2a5b0d2e5b8d210246656d87c1"
+  integrity sha512-4FcsA6+m85lcCN6whNMteclD/y8qY02qcOLwjFX9Xju+zzjE5TboGAA68jroP6qEoxWuJ16fGguZVgS7UOcnUA==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/core" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/messaging" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/core" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/messaging" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
 
-"@kiltprotocol/types@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.1.tgz#0a9ffc43f28d6e15f2963037211f1f7b24cbf470"
-  integrity sha512-6OXxWOn3TAjb7SQ4uiDpFPp9/cu3Kbna/hUsg2VKUee4Rcak5KpBWSBjZ9gIk0/wLiEtg/S8Bfb3AgS22jJV8Q==
+"@kiltprotocol/types@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.2.tgz#8b832e467f803f3682ef426c80eb6955c76f2119"
+  integrity sha512-F3GdN2UuDSDQIIBGnC2ZKhn6+YRwMxim71JjLmOEnhWj24husZyq7HMgZTYrU7RNkcpJiaMdl5eFkKat2nghNg==
   dependencies:
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
@@ -168,12 +168,12 @@
     "@polkadot/types" "^8.0.0"
     tweetnacl "^1.0.3"
 
-"@kiltprotocol/utils@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.1.tgz#691ec275a310fb204bf81860101b87f44d9e8884"
-  integrity sha512-T2whvggOpgK6D5TkNO8MM09+5vL3TEVksQ0RsfcNgLw/VkDdwTlV4MI8pIGKfH9L/1xR9g6mvv3TfXztoBznOw==
+"@kiltprotocol/utils@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.2.tgz#907f8f5b5e5400cad3207ea048547ab632103016"
+  integrity sha512-9XbFYb2qTs9ncmKR31ndxAXvqwLEOtQ9ZqK31kf2hbe4OxrI+pva/xek4hL5A1b2QErK0At2sNvU3q6lXpstUQ==
   dependencies:
-    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
     "@polkadot/types" "^8.0.0"

--- a/code_examples/core_features/yarn.lock
+++ b/code_examples/core_features/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2":
-  version "7.17.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
-  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+"@babel/runtime@^7.17.9", "@babel/runtime@^7.18.3":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -71,126 +71,126 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kiltprotocol/chain-helpers@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.27.0.tgz#ab8b78516382d112133d4220b4d954d447b3c07f"
-  integrity sha512-rpZgKmOgZ3apQQC278YEUsFWgi26VQdAU57BD2vnxMfvGL3hGBnhuRP2MEtgLlXMgFDQ5yCe48VAex350L7JMg==
+"@kiltprotocol/chain-helpers@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.1.tgz#50697bda019a6f1e3ab54369f5905fa5e04da4fb"
+  integrity sha512-iECkDmaYVk/dSIATz1KoonEBNJMrin3Rh0dHJMi0GDLbKxE031f4agHry+0x4u9yI+yGxCmte+bSRcsaIdtYVQ==
   dependencies:
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/config@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.27.0.tgz#62958f3c673b2a6f3c699b91bba48d90644f1929"
-  integrity sha512-JnMdCwPTMEsYpkDk4Ym040YB6uBiz7yscXktosc+/OQANyipcUzOVfekiOK59J6CcA9evblODW9Qt1zTsth39g==
+"@kiltprotocol/config@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.1.tgz#cfc0043a670119f48a6b7bd072625a888bc6dba3"
+  integrity sha512-tTeumsLt1inoHAOJuZTlzrtHg5nt3M78DkIKotoZSRxB+v5DGYbwrc6oF71R5/b5EdjhoxRWJbnft4Im2aA8lw==
   dependencies:
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.27.0.tgz#62c69800be49dccca3a231eeb0f39ade648c7476"
-  integrity sha512-NOsoG/rukSbi0+hPuGxfJ0tuV5or6/cUnMFxUAl1oIjt8xrKLFwBsRLnTpeowsN3vnAEToRuKG08BgurhC1ZSg==
+"@kiltprotocol/core@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.1.tgz#9c05d109e16ba5f29c07702d2ba08cabd85671af"
+  integrity sha512-JdcMZ3GpdUdu/vQKQGT0CQsztn97lTwKz7zgJfkil/6lw4hO6TONk6VkFw2F2CkwyhoKsQ1xbrj8+SyQ0Y0swA==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/types-known" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/types-known" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     tweetnacl "^1.0.3"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/did@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.27.0.tgz#8402228084644ed4c6bcafea2446f194bc8335ad"
-  integrity sha512-lJy9ykvuqLYBzAdV3To7U1K23D+S0Ll8L+bOxawLdZHNb+3o+M3BMPrLyeunvnYi6W9CxVaxBs4M/P5MvrAiqg==
+"@kiltprotocol/did@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.1.tgz#2b989bb959ba9b758d828d9427792743dc91c467"
+  integrity sha512-SrySBOJeMjLe4l1Cy6s8GUyOwOV6QYgnO1aY2t5cKSzVScWMu22Pm1/h/aDaNqLUaFKWesVZDgbPaoPan4IBHg==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.27.0.tgz#24f37bbf3833ce40de068357f084ccfda1ac8ab2"
-  integrity sha512-raoPJron5HAADWtcN0hKCVw76uoJKrM2wuakQQOudo0kuNTCPuYiVRCQZJsQfMrYEkNx/LKAKXK3nTTIF3R68Q==
+"@kiltprotocol/messaging@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.1.tgz#2f9833b93c2bea37663d1bff43cfcec341d7175c"
+  integrity sha512-Q51c3W7VPYP+9ziv0EQtxF5QiKT+yKGAEN3kMBJIZnv6QK6HBMAij6625Up+9WgfI8PCWai5VOi1PScVXR3rnA==
   dependencies:
-    "@kiltprotocol/core" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
+    "@kiltprotocol/core" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
 
-"@kiltprotocol/sdk-js@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.27.0.tgz#d166c0aaffaec29519b2d4e76e08663ec2b5dc50"
-  integrity sha512-hiyjwBmEohTS+9DXCFMKsADZag5m6+7/bhdf0RUHM/olPKbtiRajZJbjEdX84QaLOb2hVrAigk7FJLYZ9g8h3g==
+"@kiltprotocol/sdk-js@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.1.tgz#2f9292626510bc2e53c4271c6a37f0c02379b10e"
+  integrity sha512-GCTCapgnfEDc1fMWMwQdCQPPcFEqWIp4cbJdimS1UgEqQ1cIU9WiOQ/jbudkZ1ygqdiwZkzdPGSoHl/A3n2CTQ==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/core" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/messaging" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/core" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/messaging" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
 
-"@kiltprotocol/types@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.27.0.tgz#2d2c76311d1fb22c4ec816c0fdb4955aa711421b"
-  integrity sha512-tvkIj69GkoVBmkPd+8ywkiIb4KUkS3MsaMsQlONRxQztxRPk3WkBsXjj8Ta4ss4omlo0ge4i3SdFWISyiLBrrw==
+"@kiltprotocol/types@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.1.tgz#0a9ffc43f28d6e15f2963037211f1f7b24cbf470"
+  integrity sha512-6OXxWOn3TAjb7SQ4uiDpFPp9/cu3Kbna/hUsg2VKUee4Rcak5KpBWSBjZ9gIk0/wLiEtg/S8Bfb3AgS22jJV8Q==
   dependencies:
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
     tweetnacl "^1.0.3"
 
-"@kiltprotocol/utils@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.27.0.tgz#be5dbfe570669efc23ea59c12abed4882efea929"
-  integrity sha512-x43mAQ95Ee/fDBNd009vJgdB4bDaXv9Yn/PXrcrmvq6e5ZQDOD/mgDtPqmr5nTsBgdkve5x6/wX27l8fFocw7g==
+"@kiltprotocol/utils@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.1.tgz#691ec275a310fb204bf81860101b87f44d9e8884"
+  integrity sha512-T2whvggOpgK6D5TkNO8MM09+5vL3TEVksQ0RsfcNgLw/VkDdwTlV4MI8pIGKfH9L/1xR9g6mvv3TfXztoBznOw==
   dependencies:
-    "@kiltprotocol/types" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     tweetnacl "^1.0.3"
     uuid "^8.1.0"
 
-"@noble/hashes@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.0.0.tgz#d5e38bfbdaba174805a4e649f13be9a9ed3351ae"
-  integrity sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg==
+"@noble/hashes@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.1.tgz#c056d9b7166c1e7387a7453c2aff199bf7d88e5f"
+  integrity sha512-Lkp9+NijmV7eSVZqiUvt3UCuuHeJpUVmRrvh430gyJjJiuJMqkeHf6/A9lQ/smmbWV/0spDeJscscPzyB4waZg==
 
-"@noble/secp256k1@1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.5.2.tgz#40399e4fba54f588fda14fc03a4499044fdcab24"
-  integrity sha512-5mzA40W2q55VCRuC9XzmkiEnODdY0c5a7qsK2QcOfI5/MuVQyBaWGQyE6YOEF7kDwp+tDVWGsCDVJUME+wsWWw==
+"@noble/secp256k1@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.0.tgz#602afbbfcfb7e169210469b697365ef740d7e930"
+  integrity sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -213,311 +213,363 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@polkadot/api-augment@7.11.1", "@polkadot/api-augment@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-7.11.1.tgz#9866afe3281ae8371c8c645e73e848bac1f6fcd3"
-  integrity sha512-CqtmRZsr7va45r/wnsH+NZMqPyUQv46fmiHxt5gq6NC4p0ziDEVVDDHLlABx5RhQzCvdiBAccZ/X8DyMCFFGEA==
+"@polkadot/api-augment@8.9.1", "@polkadot/api-augment@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-8.9.1.tgz#25b0997ccf3d1df4641123e0d9ec29e8fb03ef62"
+  integrity sha512-yobYURNgoZcZD3QJmE34n3ZcEEUtsiivquckxjJMXnHJv3zahMyJh75tCNAXjzWn+e+SqKTVlgCpLXYlC1HJPQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/api-base" "7.11.1"
-    "@polkadot/rpc-augment" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-augment" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/api-base@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-7.11.1.tgz#fb27a7c33808a8f6542b322ffb3c6702a9e15ea8"
-  integrity sha512-MATI9tm0x3rRlipLMevWzJ4cGvMyrUGyOfwjMg3Z67U7atZgZ93LzowjzDcvSgFVM14d1tBOVWBKkCKnk7C6Zg==
+"@polkadot/api-base@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-8.9.1.tgz#e0013bbb8e72678a4eecdfb880854b2e30c840d5"
+  integrity sha512-2OpS9ArZSuUu9vg2Y5DdK7r1iB1Bjx9e+6qerPGry8um+jI+EsHJESylw5OUrR2DxvtW3Ilrk4YvYpQPa9OB4w==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/api-derive@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-7.11.1.tgz#ede6119577b08d6c94767551dc6ad17c6be64149"
-  integrity sha512-py7pqs5mLaKPNDvRZ7BcUC7obsbLIuzJT/kZFiGzJXmaObSzU2lJkGD7fV34QlpmGP+Bqb4KtlhtY+Tnq33C0w==
+"@polkadot/api-derive@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-8.9.1.tgz#d701c98db27b86dceac6d3e737f0cab4f9731045"
+  integrity sha512-zOuNK1tApg3iEC5N4yiOTaMKUykk4tkNU1htcnotOxflgdhYUi22l0JuCrEtrnG6TE2ZH8z1VQA/jK0MbLfC3A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/api" "7.11.1"
-    "@polkadot/api-augment" "7.11.1"
-    "@polkadot/api-base" "7.11.1"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api" "8.9.1"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/api@7.11.1", "@polkadot/api@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-7.11.1.tgz#0aeb86319a14a9a2a071476e6a47ee3d6b8e116c"
-  integrity sha512-VTrhVuSJrWhIww1ofYPd7EhJd1UwKntfdPNRuy/abfb6GPzYCglKV6Sze3CsbI2KawC5oo1K7Ffrdf/lJy81kg==
+"@polkadot/api@8.9.1", "@polkadot/api@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-8.9.1.tgz#c35c5d583845a5d67edfa8c3579bad143f65bcd6"
+  integrity sha512-UwQ5hWPHruqnBO2hriaPhGaOwaWZx9MVECWFJzVs0ZuhKDge9jyBp+JXud/Ly/+8VbeokYUB0DSZG/gTAO5+vg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/api-augment" "7.11.1"
-    "@polkadot/api-base" "7.11.1"
-    "@polkadot/api-derive" "7.11.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/rpc-augment" "7.11.1"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/rpc-provider" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-augment" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/types-create" "7.11.1"
-    "@polkadot/types-known" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/api-derive" "8.9.1"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/types-known" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
     eventemitter3 "^4.0.7"
-    rxjs "^7.5.4"
+    rxjs "^7.5.5"
 
-"@polkadot/keyring@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-8.4.1.tgz#71098121c60a05e1ad33653fcc521c52f22ad1b8"
-  integrity sha512-0qfS7qikUxhe6LEdCOcMRdCxEa26inJ5aSUWaf5dXy+dgy9VJiov6uXAbXdAd1UHpDvr9hvw94FX+hXsJ7Vsyw==
+"@polkadot/keyring@^9.0.0", "@polkadot/keyring@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-9.5.1.tgz#3b0851f8fffe489f1b6020e69dc9a3a8e5696172"
+  integrity sha512-ixv2lq1zNzYa+GqZQTzcraNw5ZrTTK+2/sqfeMOIr7gBGk0UCALuK0NCvTRAUtQK1RT2psBkkm2lr/rrNCeK+A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "8.4.1"
-    "@polkadot/util-crypto" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/util-crypto" "9.5.1"
 
-"@polkadot/networks@8.4.1", "@polkadot/networks@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-8.4.1.tgz#c22585edb38f5ae0a329a1f471577d8b35bf64e4"
-  integrity sha512-YFY3fPLbc1Uz9zsX4TOzjY/FF09nABMgrMkvqddrVbSgo71NvoBv3Gqw3mKV/7bX1Gzk1ODfvTzamdpsKEWSnA==
+"@polkadot/networks@9.5.1", "@polkadot/networks@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-9.5.1.tgz#876c6cf8915a47e6ace81139197f8b0d36adb362"
+  integrity sha512-1q9jm7NLk1ZMqFJL+kYkpn1phEO+N0d5LU81ropjYf0hC9boBAya4Zqvv3DwasPuLp6qaj4r0nrfzmkP5xHKZQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "8.4.1"
-    "@substrate/ss58-registry" "^1.14.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@substrate/ss58-registry" "^1.22.0"
 
-"@polkadot/rpc-augment@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-7.11.1.tgz#c77bbdae20e3933ddd2d8eea243a215e35a6861f"
-  integrity sha512-cP/g6dM5Rmdeno+sOi/PBvAEycRoi/UI1MOKb0lVhlFJayw/uyGOhHtPKOnLh2fyDJ/q66HO3pu6aem3ORFwhQ==
+"@polkadot/rpc-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-8.9.1.tgz#644061c68a9a2abe7f3574ab74b10652acae5707"
+  integrity sha512-6TtZPVjvjcPy3w4lmcNu3MTU1h2YLkZBVNwUZFnZPhALc9qBy9ZcvkMODLPfD+mj+i8Fcfn4b7Ypj+sNqXFxUQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/rpc-core@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-7.11.1.tgz#079f2c70e09015d01bfec92f06993a5538399072"
-  integrity sha512-Bp71BwOSPT4/xmYWn9e9/ikGKYYmltbceVwa0MJiuKI0Xd5YntjtJVov17Fqlt+eddkLGt74750paykvHDJWWQ==
+"@polkadot/rpc-core@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-8.9.1.tgz#79392d2a1d1d5e93549cd0f7fae7f0d71a6fb79d"
+  integrity sha512-+mAkpxIX2kIovnIIf8uxqjXqPA/7LaeysfIPi8VGrVB3IqvLEaT2rWtCMRSFkBEZwYI7vP7PrAw9co6MMkXlUw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/rpc-augment" "7.11.1"
-    "@polkadot/rpc-provider" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/rpc-provider@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-7.11.1.tgz#f0cf70c4fa3b69fb96aafbed07f8d5725db9cca8"
-  integrity sha512-07Mg+r9swMjNISDK8ntDI5gFZU8rtHeoB27/qQwZzcWugogva8rNhaInBikZPKlF7yxM6l2VMaQnOziKUNsnRw==
+"@polkadot/rpc-provider@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-8.9.1.tgz#1e6e8e6218bb0fe59dd673acb9198bf12acf6625"
+  integrity sha512-XunL29pi464VB6AJGuvVzTnCtk4y5KBwgBIC/S4YMdqi+l2ujXZOFM2WBnbiV+YhB7FEXmbYR8NsKAe/DSb85A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-support" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    "@polkadot/x-fetch" "^8.4.1"
-    "@polkadot/x-global" "^8.4.1"
-    "@polkadot/x-ws" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-support" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    "@polkadot/x-fetch" "^9.5.1"
+    "@polkadot/x-global" "^9.5.1"
+    "@polkadot/x-ws" "^9.5.1"
+    "@substrate/connect" "0.7.6"
     eventemitter3 "^4.0.7"
-    mock-socket "^9.1.2"
-    nock "^13.2.4"
+    mock-socket "^9.1.5"
+    nock "^13.2.6"
 
-"@polkadot/types-augment@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-7.11.1.tgz#2c56779dbd1cff509609db912fcc2575e0983828"
-  integrity sha512-jCnZ/eMkLaqSKl5q4JwBxslhAaJSSNHt04reZRs1i2jlC2UVgiFN1Rr5GJmHYAwDPoFcge/rAm6bckfhXUIdOw==
+"@polkadot/types-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-8.9.1.tgz#ff4880471eba038f8b28e412b7d8d1f500d46cf9"
+  integrity sha512-kfSioIpB8krtNgIANN8QCik+uBFmxGACEq84oxiqbKc2BfTXzcqQ7jkmslXeEqb9IsQ9rpaa3fkvyoLQNLqXgA==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-codec@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-7.11.1.tgz#4cfcd8ab81f6ba510a984c08eb11861b33acab38"
-  integrity sha512-rDM/FYcnou2Chy+urd7U41lcjM6jWUEUydyP9NuTOSAamCGtH0eKw52GURKTsKTT5r8wJdPMKv/yNxs1i+l5Lw==
+"@polkadot/types-codec@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-8.9.1.tgz#8fbf3ade7a87b716937b7f37fd43b8a46ba12c4d"
+  integrity sha512-bboHpTwvHooTdITsmJ5IqAyZDuONZaVs6xC3iRbE9SIHD4kUpivlTc+Rvk91EcQclFo5IUKvNrX4BrOx8Y/YnQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-create@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-7.11.1.tgz#878b5bdf278ca9456195980aa91957979a4e9342"
-  integrity sha512-nVYaJC/IDsM4WM9WGjAI7qQ9scPSlBqqzwqLdvXCJeq3trOTt68x39DD0zp0hzJ/7MeXjPToDDWjpAF0B9mWSQ==
+"@polkadot/types-create@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-8.9.1.tgz#ed365812b522fcc7984aa24cf7cbeeb0cdf20e34"
+  integrity sha512-q7er671QXYcmG4gkZvtKpES7QV013w36s8VT947aT3GDzlGZDQQKNKpELyi7K1sgWjQyrL3/0cTKhP8taAjWPQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-known@7.11.1", "@polkadot/types-known@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-7.11.1.tgz#55c42aae31813360ea54e438a761b0c48392f148"
-  integrity sha512-BBqQxG7I+wUjeLby1u5p9aSoZ5Vy0oCwmm/aKN64JH9vBEz1OOA0pRdcCooGCG/884Wb5pRpacWTepQMQkOTLw==
+"@polkadot/types-known@8.9.1", "@polkadot/types-known@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-8.9.1.tgz#019ab25b048f157659cf6141c3d8483c28af0123"
+  integrity sha512-y5Fvo7TM9DjM/CNQbQsR78O5LP3CuBbQY90yA2APwqZNn/dilTxWIGrxtPzTG9QCZJyhMN+EZdKUo51brKRI/g==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/networks" "^8.4.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/types-create" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/networks" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-support@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-7.11.1.tgz#509d942c8a9c0670a20b77fc1c98c97b7151b75e"
-  integrity sha512-pJmDUHK7DOO6mjpntxq9Lq0tjvqwc15FrrrNbuENgRiOueRqcAlzv+V80wdzoIBUwINgKphtpzu+rdQIYsVVQg==
+"@polkadot/types-support@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-8.9.1.tgz#84d023945feddc15f60b8cb1a36abe2edfed4a23"
+  integrity sha512-t3HJc8o68LWvhEy63PRZQxCL4T7sSsrLm7+rpkfeJAEC1DXeFF85FwE2U+YKa3+Z3NuMv2e4DV2jnIZe9XRtHQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types@7.11.1", "@polkadot/types@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-7.11.1.tgz#aefdd0efa98b43ebf516947a845e12fc5d63e9ae"
-  integrity sha512-jxVrxIbsSfH9xK1Q3vaCfJmbkm0OlvoXz0GxdP5RJ7dQnxlNYWQUXanFkKebbRL8gSEs1wSRVccil/TSH65Nvg==
+"@polkadot/types@8.9.1", "@polkadot/types@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-8.9.1.tgz#e5bf1cef79d8c305faa8691c62dd3d4be9baed53"
+  integrity sha512-h43/aPzk+ta0MzzGQz3DiGtearttHxZr08xOdtU5GctI6u9MXm0n0w74clciLpIGu5CI+QxYN3oQ8/5WXTukMw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types-augment" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/types-create" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/util-crypto@8.4.1", "@polkadot/util-crypto@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-8.4.1.tgz#41ff754dc995b681913fc0a484bb0d309221a703"
-  integrity sha512-mWjp83aIWw+EhKN9RkUDmubXibo25q5yHJl4BGm2gT71yTZcABB7q1SGfpDqLH9AB3eXJiutqhC4L3SH7YZ+6Q==
+"@polkadot/util-crypto@9.5.1", "@polkadot/util-crypto@^9.0.0", "@polkadot/util-crypto@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-9.5.1.tgz#f69bdccd7043620c9bd905b169ec50bf97bf6ffb"
+  integrity sha512-4YwJJ2/mXx3PXTy4WLekQOo1MlDtQzYgTZsjOagi3Uz3Q/ITvS+/iu6eF/H6Tz0uEQjwX6t9tsMkM5FWk/XoGg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@noble/hashes" "1.0.0"
-    "@noble/secp256k1" "1.5.2"
-    "@polkadot/networks" "8.4.1"
-    "@polkadot/util" "8.4.1"
-    "@polkadot/wasm-crypto" "^4.5.1"
-    "@polkadot/x-bigint" "8.4.1"
-    "@polkadot/x-randomvalues" "8.4.1"
-    "@scure/base" "1.0.0"
+    "@babel/runtime" "^7.18.3"
+    "@noble/hashes" "1.1.1"
+    "@noble/secp256k1" "1.6.0"
+    "@polkadot/networks" "9.5.1"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/wasm-crypto" "^6.1.1"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-randomvalues" "9.5.1"
+    "@scure/base" "1.1.1"
     ed2curve "^0.3.0"
     tweetnacl "^1.0.3"
 
-"@polkadot/util@8.4.1", "@polkadot/util@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-8.4.1.tgz#b84835c55585c8b5fc5608a99aa62ac815292ae7"
-  integrity sha512-8+wqHgFbFWI5TfrvtcL888w0nWvFpbTTYIcbpEw+zYGp3n1YZTAMMP26bXWAaQX5AttxynJRij7JP3ySxYY1fg==
+"@polkadot/util@9.5.1", "@polkadot/util@^9.0.0", "@polkadot/util@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-9.5.1.tgz#b9e0b8cb0d6f1fd86e1a39a843ac8defeb6d5c9f"
+  integrity sha512-cI2ar15vkoXjs//YNn1yT5eUdK7jF32XNw3Oc6YJ2qEpenwy30c3BUQJOiqW7J6UBYLYll5O5y0ejv6LQoSFBQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-bigint" "8.4.1"
-    "@polkadot/x-global" "8.4.1"
-    "@polkadot/x-textdecoder" "8.4.1"
-    "@polkadot/x-textencoder" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-global" "9.5.1"
+    "@polkadot/x-textdecoder" "9.5.1"
+    "@polkadot/x-textencoder" "9.5.1"
     "@types/bn.js" "^5.1.0"
-    bn.js "^5.2.0"
+    bn.js "^5.2.1"
     ip-regex "^4.3.0"
 
-"@polkadot/wasm-crypto-asmjs@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.5.1.tgz#e1025a49e106db11d1187caf65f56c960ea2ad2b"
-  integrity sha512-DOdRiWhxVvmqTvp+E9z1j+Yr0zDOGsDvqnT/eNw0Dl1FVUOImsEa7FKns/urASmcxCVEE1jtUWSnij29jrORMQ==
+"@polkadot/wasm-bridge@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-bridge/-/wasm-bridge-6.1.1.tgz#9342f2b3c139df72fa45c8491b348f8ebbfa57fa"
+  integrity sha512-Cy0k00VCu+HWxie+nn9GWPlSPdiZl8Id8ulSGA2FKET0jIbffmOo4e1E2FXNucfR1UPEpqov5BCF9T5YxEXZDg==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.17.9"
 
-"@polkadot/wasm-crypto-wasm@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.5.1.tgz#063a58ff7ddd939b7886a6a238109a8d2c416e46"
-  integrity sha512-hPwke85HxpgG/RAlwdCE8u5w7bThvWg399mlB+XjogXMxOUWBZSgq2XYbgzROUXx27inK9nStF4Pnc4zJnqs9A==
+"@polkadot/wasm-crypto-asmjs@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.1.1.tgz#6d09045679120b43fbfa435b29c3690d1f788ebb"
+  integrity sha512-gG4FStVumkyRNH7WcTB+hn3EEwCssJhQyi4B1BOUt+eYYmw9xJdzIhqjzSd9b/yF2e5sRaAzfnMj2srGufsE6A==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.17.9"
 
-"@polkadot/wasm-crypto@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.5.1.tgz#e1ac6d846a0ad8e991cec128994524183ef6e8fd"
-  integrity sha512-Cr21ais3Kq3aedIHZ3J1tjgeD/+K8FCiwEawr0oRywNBSJR8wyuZMePs4swR/6xm8wbBkpqoBVHz/UQHqqQJmA==
+"@polkadot/wasm-crypto-init@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.1.1.tgz#73731071bea9b4e22b380d75099da9dc683fadf5"
+  integrity sha512-rbBm/9FOOUjISL4gGNokjcKy2X+Af6Chaet4zlabatpImtPIAK26B2UUBGoaRUnvl/w6K3+GwBL4LuBC+CvzFw==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/wasm-crypto-asmjs" "^4.5.1"
-    "@polkadot/wasm-crypto-wasm" "^4.5.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-bridge" "6.1.1"
+    "@polkadot/wasm-crypto-asmjs" "6.1.1"
+    "@polkadot/wasm-crypto-wasm" "6.1.1"
 
-"@polkadot/x-bigint@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-8.4.1.tgz#d3ccddd26cdc5413f5c722d8c53ec523299e3ff1"
-  integrity sha512-QVP0UMoM0nBD998s3ESeaoSiVMEnHK3x0CCqocKO4l7ADNw8lfWdDG7Bb0+ymNaFYGz2KgEWxkN0VhNEnXzo0w==
+"@polkadot/wasm-crypto-wasm@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.1.1.tgz#3fdc8f1280710e4d68112544b2473e811c389a2a"
+  integrity sha512-zkz5Ct4KfTBT+YNEA5qbsHhTV58/FAxDave8wYIOaW4TrBnFPPs+J0WBWlGFertgIhPkvjFnQC/xzRyhet9prg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-util" "6.1.1"
 
-"@polkadot/x-fetch@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-8.4.1.tgz#7254cdb70b61aea79debd7d0c9ae5e126f78d90d"
-  integrity sha512-DPkgXZYt1B4xCzEw/3hxRc4/lR+NEr/b/GYijSPM8UsVoEKqHWTx2qCXrxvmKh1WD9reQ+oUACPVjRcBz5bs+g==
+"@polkadot/wasm-crypto@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-6.1.1.tgz#8e2c2d64d24eeaa78eb0b74ea1c438b7bc704176"
+  integrity sha512-hv9RCbMYtgjCy7+FKZFnO2Afu/whax9sk6udnZqGRBRiwaNagtyliWZGrKNGvaXMIO0VyaY4jWUwSzUgPrLu1A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
-    "@types/node-fetch" "^2.5.12"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-bridge" "6.1.1"
+    "@polkadot/wasm-crypto-asmjs" "6.1.1"
+    "@polkadot/wasm-crypto-init" "6.1.1"
+    "@polkadot/wasm-crypto-wasm" "6.1.1"
+    "@polkadot/wasm-util" "6.1.1"
+
+"@polkadot/wasm-util@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-util/-/wasm-util-6.1.1.tgz#58a566aba68f90d2a701c78ad49a1a9521b17f5b"
+  integrity sha512-DgpLoFXMT53UKcfZ8eT2GkJlJAOh89AWO+TP6a6qeZQpvXVe5f1yR45WQpkZlgZyUP+/19+kY56GK0pQxfslqg==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
+"@polkadot/x-bigint@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-9.5.1.tgz#d5d98aaa6b3de560eea23df9f696903f2e2dcf7c"
+  integrity sha512-rTp7j3KvCy8vANRoaW6j0pCQdLc/eed6uSRXoxh3z1buJhw460/Q/hJ0Bey6fyeNSDzIwFk4SGwf/Gzf+kS1vQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+
+"@polkadot/x-fetch@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-9.5.1.tgz#dda5f36de656a5db2c81a81245ad5059f95879a9"
+  integrity sha512-jMWpDVE4CyH+vVuONmvcKlJJnsRqmglmJTppsl+38JTnGL2FbELn2q92N8b5uTxmPP0lf+QTn1THXnkWvG7Ojw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+    "@types/node-fetch" "^2.6.2"
     node-fetch "^2.6.7"
 
-"@polkadot/x-global@8.4.1", "@polkadot/x-global@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-8.4.1.tgz#61def1f5962001200c17b9fde92f6837736b3c55"
-  integrity sha512-MQs89LKQrJwiXjV7dY2kDOPNaiWrwaQ/Fzg93ycB2xMCclRV1jRFRhnhTPJ8Ao79lhCCoazd7pXIyFgfifxdqg==
+"@polkadot/x-global@9.5.1", "@polkadot/x-global@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-9.5.1.tgz#a78e109ca95f5ba5e9c501a2106a9b3acfe3a682"
+  integrity sha512-asG5YlW1K3f4YjyuZ+HrbF9H5d78i5v9+7Bh+9gD+sVfB3KhqwVYZB+wzOaJkPp6lwUbBA9OBHFCVBqpR3wBJw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
+    "@babel/runtime" "^7.18.3"
 
-"@polkadot/x-randomvalues@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-8.4.1.tgz#4488d2d6b982e7b2ecafc573cd25e3f1e85a512c"
-  integrity sha512-1dRIFIib4RzyVo0k5oMLuxqSuZEV6UVvvN+jJw9G/9P1ggZtHjM1KwoFcyHgvpk2RWTB9eJZFemwSvQTpdmSJw==
+"@polkadot/x-randomvalues@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-9.5.1.tgz#e647554f7b34d4073e1bc60d8b81163d5f75f523"
+  integrity sha512-NFvG//NsBjFP01dEtQATNPn5lSAZwh6jkkUXG2rHlgvW6k8nVJ0aJPvO5MlgItgS5Ry2F88AIiSsO3cfoTpszg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-textdecoder@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-8.4.1.tgz#5a227006d183f5ec3a8a331ca38e4969d24c4a97"
-  integrity sha512-qbSXyR2KvE1bO6QGsxWU3Yrx5e70rX2lwv0MHG++MyyNaDoBM3hjx14lF911bYRWXR6MW4eZ+0Nakn0oM5uSKw==
+"@polkadot/x-textdecoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-9.5.1.tgz#13c1b48b12d350b635de385c8a0e2be14210b620"
+  integrity sha512-bY0J3Tov5y4oZi8qB/UtoEYCSgo5sDiiOa3Wmgen09LfB4gXJhWFGJSmcZqHERXCdEcmZojdbHTvOGSeYM9U1w==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-textencoder@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-8.4.1.tgz#ea01733ce6b80821bf8af943a1d98878a9150af5"
-  integrity sha512-1UYuckNOk6NUk70Y/SGbK8oyGbqPlrny1x2OWoK/BT3/tyL2xKVV5TlXDOiFrX1PChbskXye5M8blCTYikFiJg==
+"@polkadot/x-textencoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-9.5.1.tgz#76d79d07bb81e9cc7eff97043eae82c39189d8d9"
+  integrity sha512-zt121nqxiudMeZnanpnfWhCE0SOTcVRqn/atqO59us/yf6LMTf23mgd7P4795TgJwXOUcui4fhm/g/VcpsLq9Q==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-ws@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-8.4.1.tgz#502fc034588cd81ed9dc0301ca70197bf3d78799"
-  integrity sha512-u9rsJdVrBkSARy8BhJPho1yMMBSiI/Z/W8ZQRr1I28/QOwl02VYktFpFWWrhkBHsL9JlZ0wfnyKBPXrw8Wp2Vw==
+"@polkadot/x-ws@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-9.5.1.tgz#990d86c8bc54d6fe00c6ff16f341b9304dd89164"
+  integrity sha512-d91Hf7p9+mWqSvx+lZr0f7eVkHXGzNqvQnXYAizU1HE1HHl5gLixPKoGldTKrYhvV30OwKKDJChKHzvQL6nVdQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
     "@types/websocket" "^1.0.5"
     websocket "^1.0.34"
 
-"@scure/base@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
-  integrity sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==
+"@scure/base@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
-"@substrate/ss58-registry@^1.14.0":
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.16.0.tgz#100d174f38999cfba34ca02b812257a75c3fe952"
-  integrity sha512-z88145A9NE0mnDbIYRP1SlHndDtm6Jd1cRnG2InRCA/M7UprFRc0zrtaTWj1KBHfcVc2uYUMggGXuenQPBQ8yQ==
+"@substrate/connect-extension-protocol@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.0.tgz#d452beda84b3ebfcf0e88592a4695e729a91e858"
+  integrity sha512-nFVuKdp71hMd/MGlllAOh+a2hAqt8m6J2G0aSsS/RcALZexxF9jodbFc62ni8RDtJboeOfXAHhenYOANvJKPIg==
+
+"@substrate/connect@0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@substrate/connect/-/connect-0.7.6.tgz#4b1cca6bf9c0e8be93f6f6a4eeb6684993f5dc18"
+  integrity sha512-PHizR91CbjC5bzUwgYUZJrbOyoraCS1QqoxkFHteZ/0vkXDKyuzoixobDaITJqq6wSTeM8ZSjuOn9u/3q7F5+A==
+  dependencies:
+    "@substrate/connect-extension-protocol" "^1.0.0"
+    "@substrate/smoldot-light" "0.6.19"
+    eventemitter3 "^4.0.7"
+
+"@substrate/smoldot-light@0.6.19":
+  version "0.6.19"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.6.19.tgz#13e897ca9839aecb0dac4ce079ff1cca1dc54cc0"
+  integrity sha512-Xi+v1cdURhTwx7NH+9fa1U9m7VGP61GvB6qwev9HrZXlGbQiUIvySxPlH/LMsq3mwgiRYkokPhcaZEHufY7Urg==
+  dependencies:
+    buffer "^6.0.1"
+    pako "^2.0.4"
+    websocket "^1.0.32"
+
+"@substrate/ss58-registry@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.22.0.tgz#d115bc5dcab8c0f5800e05e4ef265949042b13ec"
+  integrity sha512-IKqrPY0B3AeIXEc5/JGgEhPZLy+SmVyQf+k0SIGcNSTqt1GLI3gQFEOFwSScJdem+iYZQUrn6YPPxC3TpdSC3A==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -556,10 +608,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node-fetch@^2.5.12":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
-  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -753,10 +805,15 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bn.js@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
-  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -772,6 +829,14 @@ braces@^3.0.1:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+buffer@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bufferutil@^4.0.1:
   version "4.0.6"
@@ -1446,6 +1511,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -1658,10 +1728,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -1712,10 +1782,10 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mock-socket@^9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.2.tgz#cce6cf2193aada937ba41de3288c5c1922fbd571"
-  integrity sha512-XKZkCnQ9ISOlTnaPg4LYYSMj7+6i78HyadYzLA5JM4465ibLdjappZD9Csnqc3Tfzep/eEK/LCJ29BTaLHoB1A==
+mock-socket@^9.1.5:
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.5.tgz#2c4e44922ad556843b6dfe09d14ed8041fa2cdeb"
+  integrity sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg==
 
 ms@2.0.0:
   version "2.0.0"
@@ -1742,14 +1812,14 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
-nock@^13.2.4:
-  version "13.2.4"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.4.tgz#43a309d93143ee5cdcca91358614e7bde56d20e1"
-  integrity sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==
+nock@^13.2.6:
+  version "13.2.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.7.tgz#c93933b61df42f4f4b3a07fde946a4e209c0c168"
+  integrity sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
-    lodash.set "^4.3.2"
+    lodash "^4.17.21"
     propagate "^2.0.0"
 
 node-fetch@^2.6.7:
@@ -1835,6 +1905,11 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+pako@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
+  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -1948,7 +2023,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.5.4:
+rxjs@^7.5.5:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
@@ -2237,7 +2312,7 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
-websocket@^1.0.34:
+websocket@^1.0.32, websocket@^1.0.34:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
   integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==

--- a/code_examples/vitejs/package.json
+++ b/code_examples/vitejs/package.json
@@ -8,7 +8,7 @@
     "style:fix": "yarn style --write"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.27.0",
+    "@kiltprotocol/sdk-js": "0.28.0-rc.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/code_examples/vitejs/package.json
+++ b/code_examples/vitejs/package.json
@@ -8,7 +8,7 @@
     "style:fix": "yarn style --write"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.28.0-rc.2",
+    "@kiltprotocol/sdk-js": "0.28.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/code_examples/vitejs/package.json
+++ b/code_examples/vitejs/package.json
@@ -8,7 +8,7 @@
     "style:fix": "yarn style --write"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.28.0-rc.1",
+    "@kiltprotocol/sdk-js": "0.28.0-rc.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/code_examples/vitejs/yarn.lock
+++ b/code_examples/vitejs/yarn.lock
@@ -330,14 +330,14 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kiltprotocol/chain-helpers@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.1.tgz#50697bda019a6f1e3ab54369f5905fa5e04da4fb"
-  integrity sha512-iECkDmaYVk/dSIATz1KoonEBNJMrin3Rh0dHJMi0GDLbKxE031f4agHry+0x4u9yI+yGxCmte+bSRcsaIdtYVQ==
+"@kiltprotocol/chain-helpers@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.2.tgz#0386385cde72c64ce5b59780d29e655e2a2380ad"
+  integrity sha512-1+G75zENLnH/YNaIBbaJmsaxALZ4YUwCOMKEBrXNd4tHKBLwz9U+eysBopm4trchqDZqy1lUwnuW/40eT7uOCA==
   dependencies:
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -345,25 +345,25 @@
     "@polkadot/util" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/config@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.1.tgz#cfc0043a670119f48a6b7bd072625a888bc6dba3"
-  integrity sha512-tTeumsLt1inoHAOJuZTlzrtHg5nt3M78DkIKotoZSRxB+v5DGYbwrc6oF71R5/b5EdjhoxRWJbnft4Im2aA8lw==
+"@kiltprotocol/config@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.2.tgz#7c44a514e2baaf3362356e758461c51ccb5519d6"
+  integrity sha512-/fd2DY9C7K3vUJd1FQgFYfwU+UoyEM212Kak3uSwc0notkzv2tmL9lMXRcDMMwYf11mZIgmTGR/EZwC1txerRA==
   dependencies:
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.1.tgz#9c05d109e16ba5f29c07702d2ba08cabd85671af"
-  integrity sha512-JdcMZ3GpdUdu/vQKQGT0CQsztn97lTwKz7zgJfkil/6lw4hO6TONk6VkFw2F2CkwyhoKsQ1xbrj8+SyQ0Y0swA==
+"@kiltprotocol/core@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.2.tgz#4791e8d3440ad27e72502f189a86a2af9d96e23e"
+  integrity sha512-CHrgiW+bZ8Lxw/FLBdPyuWoQfXxiQzshR4N2YlePwsgHg1dkC4ypjZ8nnu0GRGH2ZMZhZHG92ctndHsDfpFSZw==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -374,15 +374,15 @@
     tweetnacl "^1.0.3"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/did@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.1.tgz#2b989bb959ba9b758d828d9427792743dc91c467"
-  integrity sha512-SrySBOJeMjLe4l1Cy6s8GUyOwOV6QYgnO1aY2t5cKSzVScWMu22Pm1/h/aDaNqLUaFKWesVZDgbPaoPan4IBHg==
+"@kiltprotocol/did@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.2.tgz#d6639d785705071ff105b065c4d2fe707293997d"
+  integrity sha512-9C/r7TlNmmsk8hBLpsltHpJtIcnkgS2xMlUAlDzsiOcXSlEfW5z4lLFdrVV2M0hz9Ypf91RI8h/+QEvGSqgdWg==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -391,35 +391,35 @@
     "@polkadot/util-crypto" "^9.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.1.tgz#2f9833b93c2bea37663d1bff43cfcec341d7175c"
-  integrity sha512-Q51c3W7VPYP+9ziv0EQtxF5QiKT+yKGAEN3kMBJIZnv6QK6HBMAij6625Up+9WgfI8PCWai5VOi1PScVXR3rnA==
+"@kiltprotocol/messaging@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.2.tgz#c86ce6160ea2a263405909e9e5c820022940c65a"
+  integrity sha512-6dfkJBDi1fZE7FNxU3FJY9l/yFhgR3xUxsASwdS9+rhbN0R0lkyQhJdBkWc+TTBNuK3gqAgGnM4lz+HvlwlaHg==
   dependencies:
-    "@kiltprotocol/core" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/core" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/util" "^9.0.0"
 
-"@kiltprotocol/sdk-js@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.1.tgz#2f9292626510bc2e53c4271c6a37f0c02379b10e"
-  integrity sha512-GCTCapgnfEDc1fMWMwQdCQPPcFEqWIp4cbJdimS1UgEqQ1cIU9WiOQ/jbudkZ1ygqdiwZkzdPGSoHl/A3n2CTQ==
+"@kiltprotocol/sdk-js@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.2.tgz#8b07326f4f958e2a5b0d2e5b8d210246656d87c1"
+  integrity sha512-4FcsA6+m85lcCN6whNMteclD/y8qY02qcOLwjFX9Xju+zzjE5TboGAA68jroP6qEoxWuJ16fGguZVgS7UOcnUA==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/core" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/messaging" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/core" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/messaging" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
 
-"@kiltprotocol/types@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.1.tgz#0a9ffc43f28d6e15f2963037211f1f7b24cbf470"
-  integrity sha512-6OXxWOn3TAjb7SQ4uiDpFPp9/cu3Kbna/hUsg2VKUee4Rcak5KpBWSBjZ9gIk0/wLiEtg/S8Bfb3AgS22jJV8Q==
+"@kiltprotocol/types@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.2.tgz#8b832e467f803f3682ef426c80eb6955c76f2119"
+  integrity sha512-F3GdN2UuDSDQIIBGnC2ZKhn6+YRwMxim71JjLmOEnhWj24husZyq7HMgZTYrU7RNkcpJiaMdl5eFkKat2nghNg==
   dependencies:
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
@@ -427,12 +427,12 @@
     "@polkadot/types" "^8.0.0"
     tweetnacl "^1.0.3"
 
-"@kiltprotocol/utils@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.1.tgz#691ec275a310fb204bf81860101b87f44d9e8884"
-  integrity sha512-T2whvggOpgK6D5TkNO8MM09+5vL3TEVksQ0RsfcNgLw/VkDdwTlV4MI8pIGKfH9L/1xR9g6mvv3TfXztoBznOw==
+"@kiltprotocol/utils@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.2.tgz#907f8f5b5e5400cad3207ea048547ab632103016"
+  integrity sha512-9XbFYb2qTs9ncmKR31ndxAXvqwLEOtQ9ZqK31kf2hbe4OxrI+pva/xek4hL5A1b2QErK0At2sNvU3q6lXpstUQ==
   dependencies:
-    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
     "@polkadot/types" "^8.0.0"

--- a/code_examples/vitejs/yarn.lock
+++ b/code_examples/vitejs/yarn.lock
@@ -208,7 +208,7 @@
     "@babel/plugin-syntax-jsx" "^7.17.12"
     "@babel/types" "^7.17.12"
 
-"@babel/runtime@^7.17.8":
+"@babel/runtime@^7.17.9", "@babel/runtime@^7.18.3":
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
   integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
@@ -330,126 +330,126 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kiltprotocol/chain-helpers@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.27.0.tgz#ab8b78516382d112133d4220b4d954d447b3c07f"
-  integrity sha512-rpZgKmOgZ3apQQC278YEUsFWgi26VQdAU57BD2vnxMfvGL3hGBnhuRP2MEtgLlXMgFDQ5yCe48VAex350L7JMg==
+"@kiltprotocol/chain-helpers@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.1.tgz#50697bda019a6f1e3ab54369f5905fa5e04da4fb"
+  integrity sha512-iECkDmaYVk/dSIATz1KoonEBNJMrin3Rh0dHJMi0GDLbKxE031f4agHry+0x4u9yI+yGxCmte+bSRcsaIdtYVQ==
   dependencies:
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/config@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.27.0.tgz#62958f3c673b2a6f3c699b91bba48d90644f1929"
-  integrity sha512-JnMdCwPTMEsYpkDk4Ym040YB6uBiz7yscXktosc+/OQANyipcUzOVfekiOK59J6CcA9evblODW9Qt1zTsth39g==
+"@kiltprotocol/config@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.1.tgz#cfc0043a670119f48a6b7bd072625a888bc6dba3"
+  integrity sha512-tTeumsLt1inoHAOJuZTlzrtHg5nt3M78DkIKotoZSRxB+v5DGYbwrc6oF71R5/b5EdjhoxRWJbnft4Im2aA8lw==
   dependencies:
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.27.0.tgz#62c69800be49dccca3a231eeb0f39ade648c7476"
-  integrity sha512-NOsoG/rukSbi0+hPuGxfJ0tuV5or6/cUnMFxUAl1oIjt8xrKLFwBsRLnTpeowsN3vnAEToRuKG08BgurhC1ZSg==
+"@kiltprotocol/core@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.1.tgz#9c05d109e16ba5f29c07702d2ba08cabd85671af"
+  integrity sha512-JdcMZ3GpdUdu/vQKQGT0CQsztn97lTwKz7zgJfkil/6lw4hO6TONk6VkFw2F2CkwyhoKsQ1xbrj8+SyQ0Y0swA==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/types-known" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/types-known" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     tweetnacl "^1.0.3"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/did@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.27.0.tgz#8402228084644ed4c6bcafea2446f194bc8335ad"
-  integrity sha512-lJy9ykvuqLYBzAdV3To7U1K23D+S0Ll8L+bOxawLdZHNb+3o+M3BMPrLyeunvnYi6W9CxVaxBs4M/P5MvrAiqg==
+"@kiltprotocol/did@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.1.tgz#2b989bb959ba9b758d828d9427792743dc91c467"
+  integrity sha512-SrySBOJeMjLe4l1Cy6s8GUyOwOV6QYgnO1aY2t5cKSzVScWMu22Pm1/h/aDaNqLUaFKWesVZDgbPaoPan4IBHg==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.27.0.tgz#24f37bbf3833ce40de068357f084ccfda1ac8ab2"
-  integrity sha512-raoPJron5HAADWtcN0hKCVw76uoJKrM2wuakQQOudo0kuNTCPuYiVRCQZJsQfMrYEkNx/LKAKXK3nTTIF3R68Q==
+"@kiltprotocol/messaging@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.1.tgz#2f9833b93c2bea37663d1bff43cfcec341d7175c"
+  integrity sha512-Q51c3W7VPYP+9ziv0EQtxF5QiKT+yKGAEN3kMBJIZnv6QK6HBMAij6625Up+9WgfI8PCWai5VOi1PScVXR3rnA==
   dependencies:
-    "@kiltprotocol/core" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
+    "@kiltprotocol/core" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
 
-"@kiltprotocol/sdk-js@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.27.0.tgz#d166c0aaffaec29519b2d4e76e08663ec2b5dc50"
-  integrity sha512-hiyjwBmEohTS+9DXCFMKsADZag5m6+7/bhdf0RUHM/olPKbtiRajZJbjEdX84QaLOb2hVrAigk7FJLYZ9g8h3g==
+"@kiltprotocol/sdk-js@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.1.tgz#2f9292626510bc2e53c4271c6a37f0c02379b10e"
+  integrity sha512-GCTCapgnfEDc1fMWMwQdCQPPcFEqWIp4cbJdimS1UgEqQ1cIU9WiOQ/jbudkZ1ygqdiwZkzdPGSoHl/A3n2CTQ==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/core" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/messaging" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/core" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/messaging" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
 
-"@kiltprotocol/types@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.27.0.tgz#2d2c76311d1fb22c4ec816c0fdb4955aa711421b"
-  integrity sha512-tvkIj69GkoVBmkPd+8ywkiIb4KUkS3MsaMsQlONRxQztxRPk3WkBsXjj8Ta4ss4omlo0ge4i3SdFWISyiLBrrw==
+"@kiltprotocol/types@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.1.tgz#0a9ffc43f28d6e15f2963037211f1f7b24cbf470"
+  integrity sha512-6OXxWOn3TAjb7SQ4uiDpFPp9/cu3Kbna/hUsg2VKUee4Rcak5KpBWSBjZ9gIk0/wLiEtg/S8Bfb3AgS22jJV8Q==
   dependencies:
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
     tweetnacl "^1.0.3"
 
-"@kiltprotocol/utils@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.27.0.tgz#be5dbfe570669efc23ea59c12abed4882efea929"
-  integrity sha512-x43mAQ95Ee/fDBNd009vJgdB4bDaXv9Yn/PXrcrmvq6e5ZQDOD/mgDtPqmr5nTsBgdkve5x6/wX27l8fFocw7g==
+"@kiltprotocol/utils@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.1.tgz#691ec275a310fb204bf81860101b87f44d9e8884"
+  integrity sha512-T2whvggOpgK6D5TkNO8MM09+5vL3TEVksQ0RsfcNgLw/VkDdwTlV4MI8pIGKfH9L/1xR9g6mvv3TfXztoBznOw==
   dependencies:
-    "@kiltprotocol/types" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     tweetnacl "^1.0.3"
     uuid "^8.1.0"
 
-"@noble/hashes@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.0.0.tgz#d5e38bfbdaba174805a4e649f13be9a9ed3351ae"
-  integrity sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg==
+"@noble/hashes@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.1.tgz#c056d9b7166c1e7387a7453c2aff199bf7d88e5f"
+  integrity sha512-Lkp9+NijmV7eSVZqiUvt3UCuuHeJpUVmRrvh430gyJjJiuJMqkeHf6/A9lQ/smmbWV/0spDeJscscPzyB4waZg==
 
-"@noble/secp256k1@1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.5.5.tgz#315ab5745509d1a8c8e90d0bdf59823ccf9bcfc3"
-  integrity sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==
+"@noble/secp256k1@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.0.tgz#602afbbfcfb7e169210469b697365ef740d7e930"
+  integrity sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -472,300 +472,328 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@polkadot/api-augment@7.15.1", "@polkadot/api-augment@^7.10.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-7.15.1.tgz#120b766feeaa96996f1c6717a5261c2e0845c1e0"
-  integrity sha512-7csQLS6zuYuGq7W1EkTBz1ZmxyRvx/Qpz7E7zPSwxmY8Whb7Yn2effU9XF0eCcRpyfSW8LodF8wMmLxGYs1OaQ==
+"@polkadot/api-augment@8.9.1", "@polkadot/api-augment@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-8.9.1.tgz#25b0997ccf3d1df4641123e0d9ec29e8fb03ef62"
+  integrity sha512-yobYURNgoZcZD3QJmE34n3ZcEEUtsiivquckxjJMXnHJv3zahMyJh75tCNAXjzWn+e+SqKTVlgCpLXYlC1HJPQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/api-base" "7.15.1"
-    "@polkadot/rpc-augment" "7.15.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-augment" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/api-base@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-7.15.1.tgz#7567595be68431cc4085c48b18ba66933ff7b4d9"
-  integrity sha512-UlhLdljJPDwGpm5FxOjvJNFTxXMRFaMuVNx6EklbuetbBEJ/Amihhtj0EJRodxQwtZ4ZtPKYKt+g+Dn7OJJh4g==
+"@polkadot/api-base@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-8.9.1.tgz#e0013bbb8e72678a4eecdfb880854b2e30c840d5"
+  integrity sha512-2OpS9ArZSuUu9vg2Y5DdK7r1iB1Bjx9e+6qerPGry8um+jI+EsHJESylw5OUrR2DxvtW3Ilrk4YvYpQPa9OB4w==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/rpc-core" "7.15.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
     rxjs "^7.5.5"
 
-"@polkadot/api-derive@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-7.15.1.tgz#450542bb7d848013225d6c8480648340e5ee6a61"
-  integrity sha512-CsOQppksQBaa34L1fWRzmfQQpoEBwfH0yTTQxgj3h7rFYGVPxEKGeFjo1+IgI2vXXvOO73Z8E4H/MnbxvKrs1Q==
+"@polkadot/api-derive@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-8.9.1.tgz#d701c98db27b86dceac6d3e737f0cab4f9731045"
+  integrity sha512-zOuNK1tApg3iEC5N4yiOTaMKUykk4tkNU1htcnotOxflgdhYUi22l0JuCrEtrnG6TE2ZH8z1VQA/jK0MbLfC3A==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/api" "7.15.1"
-    "@polkadot/api-augment" "7.15.1"
-    "@polkadot/api-base" "7.15.1"
-    "@polkadot/rpc-core" "7.15.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/util" "^8.7.1"
-    "@polkadot/util-crypto" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api" "8.9.1"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
     rxjs "^7.5.5"
 
-"@polkadot/api@7.15.1", "@polkadot/api@^7.10.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-7.15.1.tgz#24eaeaa8ffbc6f30ff3d9846a816a18a688ceb8b"
-  integrity sha512-z0z6+k8+R9ixRMWzfsYrNDnqSV5zHKmyhTCL0I7+1I081V18MJTCFUKubrh0t1gD0/FCt3U9Ibvr4IbtukYLrQ==
+"@polkadot/api@8.9.1", "@polkadot/api@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-8.9.1.tgz#c35c5d583845a5d67edfa8c3579bad143f65bcd6"
+  integrity sha512-UwQ5hWPHruqnBO2hriaPhGaOwaWZx9MVECWFJzVs0ZuhKDge9jyBp+JXud/Ly/+8VbeokYUB0DSZG/gTAO5+vg==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/api-augment" "7.15.1"
-    "@polkadot/api-base" "7.15.1"
-    "@polkadot/api-derive" "7.15.1"
-    "@polkadot/keyring" "^8.7.1"
-    "@polkadot/rpc-augment" "7.15.1"
-    "@polkadot/rpc-core" "7.15.1"
-    "@polkadot/rpc-provider" "7.15.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-augment" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/types-create" "7.15.1"
-    "@polkadot/types-known" "7.15.1"
-    "@polkadot/util" "^8.7.1"
-    "@polkadot/util-crypto" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/api-derive" "8.9.1"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/types-known" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
     eventemitter3 "^4.0.7"
     rxjs "^7.5.5"
 
-"@polkadot/keyring@^8.4.1", "@polkadot/keyring@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-8.7.1.tgz#07cf6d6ee351dcf70fbf965b1d6d96c5025ae1b8"
-  integrity sha512-t6ZgQVC+nQT7XwbWtEhkDpiAzxKVJw8Xd/gWdww6xIrawHu7jo3SGB4QNdPgkf8TvDHYAAJiupzVQYAlOIq3GA==
+"@polkadot/keyring@^9.0.0", "@polkadot/keyring@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-9.5.1.tgz#3b0851f8fffe489f1b6020e69dc9a3a8e5696172"
+  integrity sha512-ixv2lq1zNzYa+GqZQTzcraNw5ZrTTK+2/sqfeMOIr7gBGk0UCALuK0NCvTRAUtQK1RT2psBkkm2lr/rrNCeK+A==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/util" "8.7.1"
-    "@polkadot/util-crypto" "8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/util-crypto" "9.5.1"
 
-"@polkadot/networks@8.7.1", "@polkadot/networks@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-8.7.1.tgz#26c2ec6158c985bb77c510d98a3ab1c7e049f89c"
-  integrity sha512-8xAmhDW0ry5EKcEjp6VTuwoTm0DdDo/zHsmx88P6sVL87gupuFsL+B6TrsYLl8GcaqxujwrOlKB+CKTUg7qFKg==
+"@polkadot/networks@9.5.1", "@polkadot/networks@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-9.5.1.tgz#876c6cf8915a47e6ace81139197f8b0d36adb362"
+  integrity sha512-1q9jm7NLk1ZMqFJL+kYkpn1phEO+N0d5LU81ropjYf0hC9boBAya4Zqvv3DwasPuLp6qaj4r0nrfzmkP5xHKZQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/util" "8.7.1"
-    "@substrate/ss58-registry" "^1.17.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@substrate/ss58-registry" "^1.22.0"
 
-"@polkadot/rpc-augment@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-7.15.1.tgz#391a42a9c3e553335a2a544598a717b47654ad6e"
-  integrity sha512-sK0+mphN7nGz/eNPsshVi0qd0+N0Pqxuebwc1YkUGP0f9EkDxzSGp6UjGcSwWVaAtk9WZZ1MpK1Jwb/2GrKV7Q==
+"@polkadot/rpc-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-8.9.1.tgz#644061c68a9a2abe7f3574ab74b10652acae5707"
+  integrity sha512-6TtZPVjvjcPy3w4lmcNu3MTU1h2YLkZBVNwUZFnZPhALc9qBy9ZcvkMODLPfD+mj+i8Fcfn4b7Ypj+sNqXFxUQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/rpc-core" "7.15.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/rpc-core@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-7.15.1.tgz#47855cf05bd2f8dbf87d9f1f77343114e61c664a"
-  integrity sha512-4Sb0e0PWmarCOizzxQAE1NQSr5z0n+hdkrq3+aPohGu9Rh4PodG+OWeIBy7Ov/3GgdhNQyBLG+RiVtliXecM3g==
+"@polkadot/rpc-core@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-8.9.1.tgz#79392d2a1d1d5e93549cd0f7fae7f0d71a6fb79d"
+  integrity sha512-+mAkpxIX2kIovnIIf8uxqjXqPA/7LaeysfIPi8VGrVB3IqvLEaT2rWtCMRSFkBEZwYI7vP7PrAw9co6MMkXlUw==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/rpc-augment" "7.15.1"
-    "@polkadot/rpc-provider" "7.15.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
     rxjs "^7.5.5"
 
-"@polkadot/rpc-provider@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-7.15.1.tgz#a213de907a6f4f480c3c819aa95e4e60d4247f84"
-  integrity sha512-n0RWfSaD/r90JXeJkKry1aGZwJeBUUiMpXUQ9Uvp6DYBbYEDs0fKtWLpdT3PdFrMbe5y3kwQmNLxwe6iF4+mzg==
+"@polkadot/rpc-provider@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-8.9.1.tgz#1e6e8e6218bb0fe59dd673acb9198bf12acf6625"
+  integrity sha512-XunL29pi464VB6AJGuvVzTnCtk4y5KBwgBIC/S4YMdqi+l2ujXZOFM2WBnbiV+YhB7FEXmbYR8NsKAe/DSb85A==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/keyring" "^8.7.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-support" "7.15.1"
-    "@polkadot/util" "^8.7.1"
-    "@polkadot/util-crypto" "^8.7.1"
-    "@polkadot/x-fetch" "^8.7.1"
-    "@polkadot/x-global" "^8.7.1"
-    "@polkadot/x-ws" "^8.7.1"
-    "@substrate/connect" "0.7.0-alpha.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-support" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    "@polkadot/x-fetch" "^9.5.1"
+    "@polkadot/x-global" "^9.5.1"
+    "@polkadot/x-ws" "^9.5.1"
+    "@substrate/connect" "0.7.6"
     eventemitter3 "^4.0.7"
-    mock-socket "^9.1.2"
-    nock "^13.2.4"
+    mock-socket "^9.1.5"
+    nock "^13.2.6"
 
-"@polkadot/types-augment@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-7.15.1.tgz#437047f961b8d29e5ffd4fd59cd35f0e6374750b"
-  integrity sha512-aqm7xT/66TCna0I2utpIekoquKo0K5pnkA/7WDzZ6gyD8he2h0IXfe8xWjVmuyhjxrT/C/7X1aUF2Z0xlOCwzQ==
+"@polkadot/types-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-8.9.1.tgz#ff4880471eba038f8b28e412b7d8d1f500d46cf9"
+  integrity sha512-kfSioIpB8krtNgIANN8QCik+uBFmxGACEq84oxiqbKc2BfTXzcqQ7jkmslXeEqb9IsQ9rpaa3fkvyoLQNLqXgA==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-codec@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-7.15.1.tgz#c0155867efd3ae35e15fea6a8aab49c2c63988fa"
-  integrity sha512-nI11dT7FGaeDd/fKPD8iJRFGhosOJoyjhZ0gLFFDlKCaD3AcGBRTTY8HFJpP/5QXXhZzfZsD93fVKrosnegU0Q==
+"@polkadot/types-codec@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-8.9.1.tgz#8fbf3ade7a87b716937b7f37fd43b8a46ba12c4d"
+  integrity sha512-bboHpTwvHooTdITsmJ5IqAyZDuONZaVs6xC3iRbE9SIHD4kUpivlTc+Rvk91EcQclFo5IUKvNrX4BrOx8Y/YnQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-create@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-7.15.1.tgz#ec4cafa314a82a25a109f0f52207e9169fc9b003"
-  integrity sha512-+HiaHn7XOwP0kv/rVdORlVkNuMoxuvt+jd67A/CeEreJiXqRLu+S61Mdk7wi6719PTaOal1hTDFfyGrtUd8FSQ==
+"@polkadot/types-create@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-8.9.1.tgz#ed365812b522fcc7984aa24cf7cbeeb0cdf20e34"
+  integrity sha512-q7er671QXYcmG4gkZvtKpES7QV013w36s8VT947aT3GDzlGZDQQKNKpELyi7K1sgWjQyrL3/0cTKhP8taAjWPQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-known@7.15.1", "@polkadot/types-known@^7.10.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-7.15.1.tgz#71dbf0835a48cdc97d0f50b0000298687e29818d"
-  integrity sha512-LMcNP0CxT84DqAKV62/qDeeIVIJCR5yzE9b+9AsYhyfhE4apwxjrThqZA7K0CF56bOdQJSexAerYB/jwk2IijA==
+"@polkadot/types-known@8.9.1", "@polkadot/types-known@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-8.9.1.tgz#019ab25b048f157659cf6141c3d8483c28af0123"
+  integrity sha512-y5Fvo7TM9DjM/CNQbQsR78O5LP3CuBbQY90yA2APwqZNn/dilTxWIGrxtPzTG9QCZJyhMN+EZdKUo51brKRI/g==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/networks" "^8.7.1"
-    "@polkadot/types" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/types-create" "7.15.1"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/networks" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-support@7.15.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-7.15.1.tgz#9c274759647dd89d46ea9cf74d593bcedcd85527"
-  integrity sha512-FIK251ffVo+NaUXLlaJeB5OvT7idDd3uxaoBM6IwsS87rzt2CcWMyCbu0uX89AHZUhSviVx7xaBxfkGEqMePWA==
+"@polkadot/types-support@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-8.9.1.tgz#84d023945feddc15f60b8cb1a36abe2edfed4a23"
+  integrity sha512-t3HJc8o68LWvhEy63PRZQxCL4T7sSsrLm7+rpkfeJAEC1DXeFF85FwE2U+YKa3+Z3NuMv2e4DV2jnIZe9XRtHQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/util" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types@7.15.1", "@polkadot/types@^7.10.1":
-  version "7.15.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-7.15.1.tgz#fb78886f4437fbc472e01019846fb1f229d2a177"
-  integrity sha512-KawZVS+eLR1D6O7c/P5cSUwr6biM9Qd2KwKtJIO8l1Mrxp7r+y2tQnXSSXVAd6XPdb3wVMhnIID+NW3W99TAnQ==
+"@polkadot/types@8.9.1", "@polkadot/types@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-8.9.1.tgz#e5bf1cef79d8c305faa8691c62dd3d4be9baed53"
+  integrity sha512-h43/aPzk+ta0MzzGQz3DiGtearttHxZr08xOdtU5GctI6u9MXm0n0w74clciLpIGu5CI+QxYN3oQ8/5WXTukMw==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/keyring" "^8.7.1"
-    "@polkadot/types-augment" "7.15.1"
-    "@polkadot/types-codec" "7.15.1"
-    "@polkadot/types-create" "7.15.1"
-    "@polkadot/util" "^8.7.1"
-    "@polkadot/util-crypto" "^8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
     rxjs "^7.5.5"
 
-"@polkadot/util-crypto@8.7.1", "@polkadot/util-crypto@^8.4.1", "@polkadot/util-crypto@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-8.7.1.tgz#f9fcca2895b5f160ce1c2faa0aa3054cc7aa4655"
-  integrity sha512-TaSuJ2aNrB5sYK7YXszkEv24nYJKRFqjF2OrggoMg6uYxUAECvTkldFnhtgeizMweRMxJIBu6bMHlSIutbWgjw==
+"@polkadot/util-crypto@9.5.1", "@polkadot/util-crypto@^9.0.0", "@polkadot/util-crypto@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-9.5.1.tgz#f69bdccd7043620c9bd905b169ec50bf97bf6ffb"
+  integrity sha512-4YwJJ2/mXx3PXTy4WLekQOo1MlDtQzYgTZsjOagi3Uz3Q/ITvS+/iu6eF/H6Tz0uEQjwX6t9tsMkM5FWk/XoGg==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@noble/hashes" "1.0.0"
-    "@noble/secp256k1" "1.5.5"
-    "@polkadot/networks" "8.7.1"
-    "@polkadot/util" "8.7.1"
-    "@polkadot/wasm-crypto" "^5.1.1"
-    "@polkadot/x-bigint" "8.7.1"
-    "@polkadot/x-randomvalues" "8.7.1"
-    "@scure/base" "1.0.0"
+    "@babel/runtime" "^7.18.3"
+    "@noble/hashes" "1.1.1"
+    "@noble/secp256k1" "1.6.0"
+    "@polkadot/networks" "9.5.1"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/wasm-crypto" "^6.1.1"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-randomvalues" "9.5.1"
+    "@scure/base" "1.1.1"
     ed2curve "^0.3.0"
     tweetnacl "^1.0.3"
 
-"@polkadot/util@8.7.1", "@polkadot/util@^8.4.1", "@polkadot/util@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-8.7.1.tgz#27fe93bf7b8345276f10cfe9c0380510cd4584f6"
-  integrity sha512-XjY1bTo7V6OvOCe4yn8H2vifeuBciCy0gq0k5P1tlGUQLI/Yt0hvDmxcA0FEPtqg8CL+rYRG7WXGPVNjkrNvyQ==
+"@polkadot/util@9.5.1", "@polkadot/util@^9.0.0", "@polkadot/util@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-9.5.1.tgz#b9e0b8cb0d6f1fd86e1a39a843ac8defeb6d5c9f"
+  integrity sha512-cI2ar15vkoXjs//YNn1yT5eUdK7jF32XNw3Oc6YJ2qEpenwy30c3BUQJOiqW7J6UBYLYll5O5y0ejv6LQoSFBQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-bigint" "8.7.1"
-    "@polkadot/x-global" "8.7.1"
-    "@polkadot/x-textdecoder" "8.7.1"
-    "@polkadot/x-textencoder" "8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-global" "9.5.1"
+    "@polkadot/x-textdecoder" "9.5.1"
+    "@polkadot/x-textencoder" "9.5.1"
     "@types/bn.js" "^5.1.0"
-    bn.js "^5.2.0"
+    bn.js "^5.2.1"
     ip-regex "^4.3.0"
 
-"@polkadot/wasm-crypto-asmjs@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-5.1.1.tgz#6648e9c6f627501f61aef570e110022f2be1eff2"
-  integrity sha512-1WBwc2G3pZMKW1T01uXzKE30Sg22MXmF3RbbZiWWk3H2d/Er4jZQRpjumxO5YGWan+xOb7HQQdwnrUnrPgbDhg==
+"@polkadot/wasm-bridge@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-bridge/-/wasm-bridge-6.1.1.tgz#9342f2b3c139df72fa45c8491b348f8ebbfa57fa"
+  integrity sha512-Cy0k00VCu+HWxie+nn9GWPlSPdiZl8Id8ulSGA2FKET0jIbffmOo4e1E2FXNucfR1UPEpqov5BCF9T5YxEXZDg==
   dependencies:
-    "@babel/runtime" "^7.17.8"
+    "@babel/runtime" "^7.17.9"
 
-"@polkadot/wasm-crypto-wasm@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-5.1.1.tgz#dc371755a05fe93f87a2754a2bcf1ff42e4bb541"
-  integrity sha512-F9PZ30J2S8vUNl2oY7Myow5Xsx5z5uNVpnNlJwlmY8IXBvyucvyQ4HSdhJsrbs4W1BfFc0mHghxgp0FbBCnf/Q==
+"@polkadot/wasm-crypto-asmjs@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.1.1.tgz#6d09045679120b43fbfa435b29c3690d1f788ebb"
+  integrity sha512-gG4FStVumkyRNH7WcTB+hn3EEwCssJhQyi4B1BOUt+eYYmw9xJdzIhqjzSd9b/yF2e5sRaAzfnMj2srGufsE6A==
   dependencies:
-    "@babel/runtime" "^7.17.8"
+    "@babel/runtime" "^7.17.9"
 
-"@polkadot/wasm-crypto@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-5.1.1.tgz#d1f8a0da631028ba904c374c1e8496ab3ba4636b"
-  integrity sha512-JCcAVfH8DhYuEyd4oX1ouByxhou0TvpErKn8kHjtzt7+tRoFi0nzWlmK4z49vszsV3JJgXxV81i10C0BYlwTcQ==
+"@polkadot/wasm-crypto-init@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.1.1.tgz#73731071bea9b4e22b380d75099da9dc683fadf5"
+  integrity sha512-rbBm/9FOOUjISL4gGNokjcKy2X+Af6Chaet4zlabatpImtPIAK26B2UUBGoaRUnvl/w6K3+GwBL4LuBC+CvzFw==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/wasm-crypto-asmjs" "^5.1.1"
-    "@polkadot/wasm-crypto-wasm" "^5.1.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-bridge" "6.1.1"
+    "@polkadot/wasm-crypto-asmjs" "6.1.1"
+    "@polkadot/wasm-crypto-wasm" "6.1.1"
 
-"@polkadot/x-bigint@8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-8.7.1.tgz#a496225def32e98c430c76b91c1579f48acf501a"
-  integrity sha512-ClkhgdB/KqcAKk3zA6Qw8wBL6Wz67pYTPkrAtImpvoPJmR+l4RARauv+MH34JXMUNlNb3aUwqN6lq2Z1zN+mJg==
+"@polkadot/wasm-crypto-wasm@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.1.1.tgz#3fdc8f1280710e4d68112544b2473e811c389a2a"
+  integrity sha512-zkz5Ct4KfTBT+YNEA5qbsHhTV58/FAxDave8wYIOaW4TrBnFPPs+J0WBWlGFertgIhPkvjFnQC/xzRyhet9prg==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-global" "8.7.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-util" "6.1.1"
 
-"@polkadot/x-fetch@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-8.7.1.tgz#dc866e7aa87c39b2e64c87f734b8fbaf1b9190e1"
-  integrity sha512-ygNparcalYFGbspXtdtZOHvNXZBkNgmNO+um9C0JYq74K5OY9/be93uyfJKJ8JcRJtOqBfVDsJpbiRkuJ1PRfg==
+"@polkadot/wasm-crypto@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-6.1.1.tgz#8e2c2d64d24eeaa78eb0b74ea1c438b7bc704176"
+  integrity sha512-hv9RCbMYtgjCy7+FKZFnO2Afu/whax9sk6udnZqGRBRiwaNagtyliWZGrKNGvaXMIO0VyaY4jWUwSzUgPrLu1A==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-global" "8.7.1"
-    "@types/node-fetch" "^2.6.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-bridge" "6.1.1"
+    "@polkadot/wasm-crypto-asmjs" "6.1.1"
+    "@polkadot/wasm-crypto-init" "6.1.1"
+    "@polkadot/wasm-crypto-wasm" "6.1.1"
+    "@polkadot/wasm-util" "6.1.1"
+
+"@polkadot/wasm-util@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-util/-/wasm-util-6.1.1.tgz#58a566aba68f90d2a701c78ad49a1a9521b17f5b"
+  integrity sha512-DgpLoFXMT53UKcfZ8eT2GkJlJAOh89AWO+TP6a6qeZQpvXVe5f1yR45WQpkZlgZyUP+/19+kY56GK0pQxfslqg==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
+"@polkadot/x-bigint@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-9.5.1.tgz#d5d98aaa6b3de560eea23df9f696903f2e2dcf7c"
+  integrity sha512-rTp7j3KvCy8vANRoaW6j0pCQdLc/eed6uSRXoxh3z1buJhw460/Q/hJ0Bey6fyeNSDzIwFk4SGwf/Gzf+kS1vQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+
+"@polkadot/x-fetch@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-9.5.1.tgz#dda5f36de656a5db2c81a81245ad5059f95879a9"
+  integrity sha512-jMWpDVE4CyH+vVuONmvcKlJJnsRqmglmJTppsl+38JTnGL2FbELn2q92N8b5uTxmPP0lf+QTn1THXnkWvG7Ojw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+    "@types/node-fetch" "^2.6.2"
     node-fetch "^2.6.7"
 
-"@polkadot/x-global@8.7.1", "@polkadot/x-global@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-8.7.1.tgz#b972044125a4fe059f4aef7c15a4e22d18179095"
-  integrity sha512-WOgUor16IihgNVdiTVGAWksYLUAlqjmODmIK1cuWrLOZtV1VBomWcb3obkO9sh5P6iWziAvCB/i+L0vnTN9ZCA==
+"@polkadot/x-global@9.5.1", "@polkadot/x-global@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-9.5.1.tgz#a78e109ca95f5ba5e9c501a2106a9b3acfe3a682"
+  integrity sha512-asG5YlW1K3f4YjyuZ+HrbF9H5d78i5v9+7Bh+9gD+sVfB3KhqwVYZB+wzOaJkPp6lwUbBA9OBHFCVBqpR3wBJw==
   dependencies:
-    "@babel/runtime" "^7.17.8"
+    "@babel/runtime" "^7.18.3"
 
-"@polkadot/x-randomvalues@8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-8.7.1.tgz#b7cc358c2a6d20f7e7798d45d1d5c7ac8c9ab4f2"
-  integrity sha512-njt17MlfN6yNyNEti7fL12lr5qM6A1aSGkWKVuqzc7XwSBesifJuW4km5u6r2gwhXjH2eHDv9SoQ7WXu8vrrkg==
+"@polkadot/x-randomvalues@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-9.5.1.tgz#e647554f7b34d4073e1bc60d8b81163d5f75f523"
+  integrity sha512-NFvG//NsBjFP01dEtQATNPn5lSAZwh6jkkUXG2rHlgvW6k8nVJ0aJPvO5MlgItgS5Ry2F88AIiSsO3cfoTpszg==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-global" "8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-textdecoder@8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-8.7.1.tgz#b706ef98d5a033d02c633009fb8dab4a4f9d7d55"
-  integrity sha512-ia0Ie2zi4VdQdNVD2GE2FZzBMfX//hEL4w546RMJfZM2LqDS674LofHmcyrsv5zscLnnRyCxZC1+J2dt+6MDIA==
+"@polkadot/x-textdecoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-9.5.1.tgz#13c1b48b12d350b635de385c8a0e2be14210b620"
+  integrity sha512-bY0J3Tov5y4oZi8qB/UtoEYCSgo5sDiiOa3Wmgen09LfB4gXJhWFGJSmcZqHERXCdEcmZojdbHTvOGSeYM9U1w==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-global" "8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-textencoder@8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-8.7.1.tgz#7820e30081e8e0a607c1c27b9e3486d82d1a723e"
-  integrity sha512-XDO0A27Xy+eJCKSxENroB8Dcnl+UclGG4ZBei+P/BqZ9rsjskUyd2Vsl6peMXAcsxwOE7g0uTvujoGM8jpKOXw==
+"@polkadot/x-textencoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-9.5.1.tgz#76d79d07bb81e9cc7eff97043eae82c39189d8d9"
+  integrity sha512-zt121nqxiudMeZnanpnfWhCE0SOTcVRqn/atqO59us/yf6LMTf23mgd7P4795TgJwXOUcui4fhm/g/VcpsLq9Q==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-global" "8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-ws@^8.7.1":
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-8.7.1.tgz#501c63c575e04bba68bdc32448e2c9b692f0411e"
-  integrity sha512-Mt0tcNzGXyKnN3DQ06alkv+JLtTfXWu6zSypFrrKHSQe3u79xMQ1nSicmpT3gWLhIa8YF+8CYJXMrqaXgCnDhw==
+"@polkadot/x-ws@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-9.5.1.tgz#990d86c8bc54d6fe00c6ff16f341b9304dd89164"
+  integrity sha512-d91Hf7p9+mWqSvx+lZr0f7eVkHXGzNqvQnXYAizU1HE1HHl5gLixPKoGldTKrYhvV30OwKKDJChKHzvQL6nVdQ==
   dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@polkadot/x-global" "8.7.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
     "@types/websocket" "^1.0.5"
     websocket "^1.0.34"
 
@@ -777,35 +805,35 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
-"@scure/base@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
-  integrity sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==
+"@scure/base@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
 "@substrate/connect-extension-protocol@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.0.tgz#d452beda84b3ebfcf0e88592a4695e729a91e858"
   integrity sha512-nFVuKdp71hMd/MGlllAOh+a2hAqt8m6J2G0aSsS/RcALZexxF9jodbFc62ni8RDtJboeOfXAHhenYOANvJKPIg==
 
-"@substrate/connect@0.7.0-alpha.0":
-  version "0.7.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@substrate/connect/-/connect-0.7.0-alpha.0.tgz#df605f4e808b58d146ad0272a79b2c4b870459a5"
-  integrity sha512-fvO7w++M8R95R/pGJFW9+cWOt8OYnnTfgswxtlPqSgzqX4tta8xcNQ51crC72FcL5agwSGkA1gc2/+eyTj7O8A==
+"@substrate/connect@0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@substrate/connect/-/connect-0.7.6.tgz#4b1cca6bf9c0e8be93f6f6a4eeb6684993f5dc18"
+  integrity sha512-PHizR91CbjC5bzUwgYUZJrbOyoraCS1QqoxkFHteZ/0vkXDKyuzoixobDaITJqq6wSTeM8ZSjuOn9u/3q7F5+A==
   dependencies:
     "@substrate/connect-extension-protocol" "^1.0.0"
-    "@substrate/smoldot-light" "0.6.8"
+    "@substrate/smoldot-light" "0.6.19"
     eventemitter3 "^4.0.7"
 
-"@substrate/smoldot-light@0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.6.8.tgz#e626e25cd2386824f1164e7d7dda7258580c36e4"
-  integrity sha512-9lVwbG6wrtss0sd6013BJGe4WN4taujsGG49pwyt1Lj36USeL2Sb164TTUxmZF/g2NQEqDPwPROBdekQ2gFmgg==
+"@substrate/smoldot-light@0.6.19":
+  version "0.6.19"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.6.19.tgz#13e897ca9839aecb0dac4ce079ff1cca1dc54cc0"
+  integrity sha512-Xi+v1cdURhTwx7NH+9fa1U9m7VGP61GvB6qwev9HrZXlGbQiUIvySxPlH/LMsq3mwgiRYkokPhcaZEHufY7Urg==
   dependencies:
     buffer "^6.0.1"
     pako "^2.0.4"
     websocket "^1.0.32"
 
-"@substrate/ss58-registry@^1.17.0":
+"@substrate/ss58-registry@^1.22.0":
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.22.0.tgz#d115bc5dcab8c0f5800e05e4ef265949042b13ec"
   integrity sha512-IKqrPY0B3AeIXEc5/JGgEhPZLy+SmVyQf+k0SIGcNSTqt1GLI3gQFEOFwSScJdem+iYZQUrn6YPPxC3TpdSC3A==
@@ -827,10 +855,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node-fetch@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
-  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -1052,7 +1080,7 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-bn.js@^5.2.0:
+bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
@@ -2233,7 +2261,7 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-mock-socket@^9.1.2:
+mock-socket@^9.1.5:
   version "9.1.5"
   resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.5.tgz#2c4e44922ad556843b6dfe09d14ed8041fa2cdeb"
   integrity sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg==
@@ -2268,10 +2296,10 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
-nock@^13.2.4:
-  version "13.2.6"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.6.tgz#35e419cd9d385ffa67e59523d9699e41b29e1a03"
-  integrity sha512-GbyeSwSEP0FYouzETZ0l/XNm5tNcDNcXJKw3LCAb+mx8bZSwg1wEEvdL0FAyg5TkBJYiWSCtw6ag4XfmBy60FA==
+nock@^13.2.6:
+  version "13.2.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.7.tgz#c93933b61df42f4f4b3a07fde946a4e209c0c168"
+  integrity sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"

--- a/code_examples/workshop/attester/attestClaim.ts
+++ b/code_examples/workshop/attester/attestClaim.ts
@@ -15,16 +15,14 @@ export async function attestClaim(
 
   // load account & DID
   const mnemonic = process.env.ATTESTER_MNEMONIC as string
-  const attesterDid = process.env.ATTESTER_DID_URI as string
+  const attesterDid = process.env.ATTESTER_DID_URI as Kilt.DidUri
   const account = await getAccount(mnemonic)
   const keystore = new Kilt.Did.DemoKeystore()
   await generateKeypairs(keystore, mnemonic)
-  const fullDid = await getFullDid(
-    Kilt.Did.DidUtils.getIdentifierFromKiltDid(attesterDid)
-  )
+  const fullDid = await getFullDid(attesterDid)
 
   // build the attestation object
-  const attestation = Kilt.Attestation.fromRequestAndDid(request, fullDid.did)
+  const attestation = Kilt.Attestation.fromRequestAndDid(request, fullDid.uri)
 
   // check the request content and deny based on your business logic.
   // e.g., verify age with other credentials (birth certificate, passport, ...)

--- a/code_examples/workshop/attester/generateCtype.ts
+++ b/code_examples/workshop/attester/generateCtype.ts
@@ -11,7 +11,7 @@ export async function ensureStoredCtype(): Promise<Kilt.CType> {
   // Init
   await Kilt.init({ address: process.env.WSS_ADDRESS })
   const mnemonic = process.env.ATTESTER_MNEMONIC as string
-  const did = process.env.ATTESTER_DID_URI as string
+  const did = process.env.ATTESTER_DID_URI as Kilt.DidUri
 
   // Load Account
   const account = await getAccount(mnemonic)
@@ -19,9 +19,7 @@ export async function ensureStoredCtype(): Promise<Kilt.CType> {
   // Load DID
   const keystore = new Kilt.Did.DemoKeystore()
   await generateKeypairs(keystore, mnemonic)
-  const fullDid = await getFullDid(
-    Kilt.Did.DidUtils.getIdentifierFromKiltDid(did)
-  )
+  const fullDid = await getFullDid(did)
 
   // get the CTYPE and see if it's stored, if yes return it
   const ctype = getCtypeSchema()

--- a/code_examples/workshop/attester/generateDid.ts
+++ b/code_examples/workshop/attester/generateDid.ts
@@ -23,7 +23,7 @@ export async function createFullDid(): Promise<Kilt.Did.FullDidDetails> {
     .addEncryptionKey(keys.keyAgreement)
     .setAttestationKey(keys.assertionMethod)
     .setDelegationKey(keys.capabilityDelegation)
-    .consumeWithHandler(keystore, account.address, async (creationTx) => {
+    .buildAndSubmit(keystore, account.address, async (creationTx) => {
       await Kilt.BlockchainUtils.signAndSubmitTx(creationTx, account, {
         resolveOn: Kilt.BlockchainUtils.IS_FINALIZED
       })
@@ -31,12 +31,11 @@ export async function createFullDid(): Promise<Kilt.Did.FullDidDetails> {
 }
 
 export async function getFullDid(
-  didIdentifier: Kilt.IDidIdentifier
+  didUri: Kilt.DidUri
 ): Promise<Kilt.Did.FullDidDetails> {
   // make sure the did is already on chain
-  const onChain = await Kilt.Did.FullDidDetails.fromChainInfo(didIdentifier)
-  if (!onChain)
-    throw Error(`failed to find on chain did: did:kilt:${didIdentifier}`)
+  const onChain = await Kilt.Did.FullDidDetails.fromChainInfo(didUri)
+  if (!onChain) throw Error(`failed to find on chain did: ${didUri}`)
   return onChain
 }
 
@@ -50,7 +49,7 @@ if (require.main === module) {
     })
     .then((did) => {
       console.log('\nsave following to .env to continue\n')
-      console.error(`ATTESTER_DID_URI=${did.did}\n`)
+      console.error(`ATTESTER_DID_URI=${did.uri}\n`)
       process.exit()
     })
 }

--- a/code_examples/workshop/claimer/createClaim.ts
+++ b/code_examples/workshop/claimer/createClaim.ts
@@ -9,7 +9,7 @@ export function createClaim(
   const claim = Kilt.Claim.fromCTypeAndClaimContents(
     ctype,
     content,
-    lightDid.did
+    lightDid.uri
   )
 
   return claim

--- a/code_examples/workshop/claimer/generateLightDid.ts
+++ b/code_examples/workshop/claimer/generateLightDid.ts
@@ -44,6 +44,6 @@ if (require.main === module) {
     .then(({ lightDid, mnemonic }) => {
       console.log('\nsave following to .env to continue\n')
       console.log(`CLAIMER_MNEMONIC="${mnemonic}"`)
-      console.log(`CLAIMER_DID_URI="${lightDid.did}"`)
+      console.log(`CLAIMER_DID_URI="${lightDid.uri}"`)
     })
 }

--- a/code_examples/workshop/package.json
+++ b/code_examples/workshop/package.json
@@ -10,7 +10,7 @@
     "test": "ts-node test.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.28.0-rc.2",
+    "@kiltprotocol/sdk-js": "0.28.0",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {

--- a/code_examples/workshop/package.json
+++ b/code_examples/workshop/package.json
@@ -10,7 +10,7 @@
     "test": "ts-node test.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.27.0",
+    "@kiltprotocol/sdk-js": "0.28.0-rc.1",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {

--- a/code_examples/workshop/package.json
+++ b/code_examples/workshop/package.json
@@ -10,7 +10,7 @@
     "test": "ts-node test.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.28.0-rc.1",
+    "@kiltprotocol/sdk-js": "0.28.0-rc.2",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {

--- a/code_examples/workshop/test.ts
+++ b/code_examples/workshop/test.ts
@@ -22,7 +22,7 @@ async function testWorkshop() {
 
   // setup claimer & create attestation request
   const { lightDid: claimerDid, mnemonic: claimerMnemonic } = await generateLightDid()
-  process.env.CLAIMER_DID_URI = claimerDid.did
+  process.env.CLAIMER_DID_URI = claimerDid.uri
   process.env.CLAIMER_MNEMONIC = claimerMnemonic
 
   await generateRequest({
@@ -54,7 +54,7 @@ async function testWorkshop() {
 
   // create attester did & ensure ctype
   const attesterDid = await createFullDid()
-  process.env.ATTESTER_DID_URI = attesterDid.did
+  process.env.ATTESTER_DID_URI = attesterDid.uri
 
   await ensureStoredCtype()
 

--- a/code_examples/workshop/yarn.lock
+++ b/code_examples/workshop/yarn.lock
@@ -71,14 +71,14 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kiltprotocol/chain-helpers@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.1.tgz#50697bda019a6f1e3ab54369f5905fa5e04da4fb"
-  integrity sha512-iECkDmaYVk/dSIATz1KoonEBNJMrin3Rh0dHJMi0GDLbKxE031f4agHry+0x4u9yI+yGxCmte+bSRcsaIdtYVQ==
+"@kiltprotocol/chain-helpers@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.2.tgz#0386385cde72c64ce5b59780d29e655e2a2380ad"
+  integrity sha512-1+G75zENLnH/YNaIBbaJmsaxALZ4YUwCOMKEBrXNd4tHKBLwz9U+eysBopm4trchqDZqy1lUwnuW/40eT7uOCA==
   dependencies:
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -86,25 +86,25 @@
     "@polkadot/util" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/config@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.1.tgz#cfc0043a670119f48a6b7bd072625a888bc6dba3"
-  integrity sha512-tTeumsLt1inoHAOJuZTlzrtHg5nt3M78DkIKotoZSRxB+v5DGYbwrc6oF71R5/b5EdjhoxRWJbnft4Im2aA8lw==
+"@kiltprotocol/config@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.2.tgz#7c44a514e2baaf3362356e758461c51ccb5519d6"
+  integrity sha512-/fd2DY9C7K3vUJd1FQgFYfwU+UoyEM212Kak3uSwc0notkzv2tmL9lMXRcDMMwYf11mZIgmTGR/EZwC1txerRA==
   dependencies:
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.1.tgz#9c05d109e16ba5f29c07702d2ba08cabd85671af"
-  integrity sha512-JdcMZ3GpdUdu/vQKQGT0CQsztn97lTwKz7zgJfkil/6lw4hO6TONk6VkFw2F2CkwyhoKsQ1xbrj8+SyQ0Y0swA==
+"@kiltprotocol/core@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.2.tgz#4791e8d3440ad27e72502f189a86a2af9d96e23e"
+  integrity sha512-CHrgiW+bZ8Lxw/FLBdPyuWoQfXxiQzshR4N2YlePwsgHg1dkC4ypjZ8nnu0GRGH2ZMZhZHG92ctndHsDfpFSZw==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -115,15 +115,15 @@
     tweetnacl "^1.0.3"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/did@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.1.tgz#2b989bb959ba9b758d828d9427792743dc91c467"
-  integrity sha512-SrySBOJeMjLe4l1Cy6s8GUyOwOV6QYgnO1aY2t5cKSzVScWMu22Pm1/h/aDaNqLUaFKWesVZDgbPaoPan4IBHg==
+"@kiltprotocol/did@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.2.tgz#d6639d785705071ff105b065c4d2fe707293997d"
+  integrity sha512-9C/r7TlNmmsk8hBLpsltHpJtIcnkgS2xMlUAlDzsiOcXSlEfW5z4lLFdrVV2M0hz9Ypf91RI8h/+QEvGSqgdWg==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/config" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/config" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
@@ -132,35 +132,35 @@
     "@polkadot/util-crypto" "^9.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.1.tgz#2f9833b93c2bea37663d1bff43cfcec341d7175c"
-  integrity sha512-Q51c3W7VPYP+9ziv0EQtxF5QiKT+yKGAEN3kMBJIZnv6QK6HBMAij6625Up+9WgfI8PCWai5VOi1PScVXR3rnA==
+"@kiltprotocol/messaging@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.2.tgz#c86ce6160ea2a263405909e9e5c820022940c65a"
+  integrity sha512-6dfkJBDi1fZE7FNxU3FJY9l/yFhgR3xUxsASwdS9+rhbN0R0lkyQhJdBkWc+TTBNuK3gqAgGnM4lz+HvlwlaHg==
   dependencies:
-    "@kiltprotocol/core" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/core" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/util" "^9.0.0"
 
-"@kiltprotocol/sdk-js@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.1.tgz#2f9292626510bc2e53c4271c6a37f0c02379b10e"
-  integrity sha512-GCTCapgnfEDc1fMWMwQdCQPPcFEqWIp4cbJdimS1UgEqQ1cIU9WiOQ/jbudkZ1ygqdiwZkzdPGSoHl/A3n2CTQ==
+"@kiltprotocol/sdk-js@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.2.tgz#8b07326f4f958e2a5b0d2e5b8d210246656d87c1"
+  integrity sha512-4FcsA6+m85lcCN6whNMteclD/y8qY02qcOLwjFX9Xju+zzjE5TboGAA68jroP6qEoxWuJ16fGguZVgS7UOcnUA==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
-    "@kiltprotocol/core" "0.28.0-rc.1"
-    "@kiltprotocol/did" "0.28.0-rc.1"
-    "@kiltprotocol/messaging" "0.28.0-rc.1"
-    "@kiltprotocol/types" "0.28.0-rc.1"
-    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.2"
+    "@kiltprotocol/core" "0.28.0-rc.2"
+    "@kiltprotocol/did" "0.28.0-rc.2"
+    "@kiltprotocol/messaging" "0.28.0-rc.2"
+    "@kiltprotocol/types" "0.28.0-rc.2"
+    "@kiltprotocol/utils" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
 
-"@kiltprotocol/types@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.1.tgz#0a9ffc43f28d6e15f2963037211f1f7b24cbf470"
-  integrity sha512-6OXxWOn3TAjb7SQ4uiDpFPp9/cu3Kbna/hUsg2VKUee4Rcak5KpBWSBjZ9gIk0/wLiEtg/S8Bfb3AgS22jJV8Q==
+"@kiltprotocol/types@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.2.tgz#8b832e467f803f3682ef426c80eb6955c76f2119"
+  integrity sha512-F3GdN2UuDSDQIIBGnC2ZKhn6+YRwMxim71JjLmOEnhWj24husZyq7HMgZTYrU7RNkcpJiaMdl5eFkKat2nghNg==
   dependencies:
     "@polkadot/api" "^8.0.0"
     "@polkadot/api-augment" "^8.0.0"
@@ -168,12 +168,12 @@
     "@polkadot/types" "^8.0.0"
     tweetnacl "^1.0.3"
 
-"@kiltprotocol/utils@0.28.0-rc.1":
-  version "0.28.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.1.tgz#691ec275a310fb204bf81860101b87f44d9e8884"
-  integrity sha512-T2whvggOpgK6D5TkNO8MM09+5vL3TEVksQ0RsfcNgLw/VkDdwTlV4MI8pIGKfH9L/1xR9g6mvv3TfXztoBznOw==
+"@kiltprotocol/utils@0.28.0-rc.2":
+  version "0.28.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.2.tgz#907f8f5b5e5400cad3207ea048547ab632103016"
+  integrity sha512-9XbFYb2qTs9ncmKR31ndxAXvqwLEOtQ9ZqK31kf2hbe4OxrI+pva/xek4hL5A1b2QErK0At2sNvU3q6lXpstUQ==
   dependencies:
-    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.2"
     "@polkadot/api-augment" "^8.0.0"
     "@polkadot/keyring" "^9.0.0"
     "@polkadot/types" "^8.0.0"

--- a/code_examples/workshop/yarn.lock
+++ b/code_examples/workshop/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2":
-  version "7.17.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
-  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+"@babel/runtime@^7.17.9", "@babel/runtime@^7.18.3":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -71,126 +71,126 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kiltprotocol/chain-helpers@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.27.0.tgz#ab8b78516382d112133d4220b4d954d447b3c07f"
-  integrity sha512-rpZgKmOgZ3apQQC278YEUsFWgi26VQdAU57BD2vnxMfvGL3hGBnhuRP2MEtgLlXMgFDQ5yCe48VAex350L7JMg==
+"@kiltprotocol/chain-helpers@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.28.0-rc.1.tgz#50697bda019a6f1e3ab54369f5905fa5e04da4fb"
+  integrity sha512-iECkDmaYVk/dSIATz1KoonEBNJMrin3Rh0dHJMi0GDLbKxE031f4agHry+0x4u9yI+yGxCmte+bSRcsaIdtYVQ==
   dependencies:
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/config@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.27.0.tgz#62958f3c673b2a6f3c699b91bba48d90644f1929"
-  integrity sha512-JnMdCwPTMEsYpkDk4Ym040YB6uBiz7yscXktosc+/OQANyipcUzOVfekiOK59J6CcA9evblODW9Qt1zTsth39g==
+"@kiltprotocol/config@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.28.0-rc.1.tgz#cfc0043a670119f48a6b7bd072625a888bc6dba3"
+  integrity sha512-tTeumsLt1inoHAOJuZTlzrtHg5nt3M78DkIKotoZSRxB+v5DGYbwrc6oF71R5/b5EdjhoxRWJbnft4Im2aA8lw==
   dependencies:
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.27.0.tgz#62c69800be49dccca3a231eeb0f39ade648c7476"
-  integrity sha512-NOsoG/rukSbi0+hPuGxfJ0tuV5or6/cUnMFxUAl1oIjt8xrKLFwBsRLnTpeowsN3vnAEToRuKG08BgurhC1ZSg==
+"@kiltprotocol/core@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.28.0-rc.1.tgz#9c05d109e16ba5f29c07702d2ba08cabd85671af"
+  integrity sha512-JdcMZ3GpdUdu/vQKQGT0CQsztn97lTwKz7zgJfkil/6lw4hO6TONk6VkFw2F2CkwyhoKsQ1xbrj8+SyQ0Y0swA==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/types-known" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/types-known" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     tweetnacl "^1.0.3"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/did@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.27.0.tgz#8402228084644ed4c6bcafea2446f194bc8335ad"
-  integrity sha512-lJy9ykvuqLYBzAdV3To7U1K23D+S0Ll8L+bOxawLdZHNb+3o+M3BMPrLyeunvnYi6W9CxVaxBs4M/P5MvrAiqg==
+"@kiltprotocol/did@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.28.0-rc.1.tgz#2b989bb959ba9b758d828d9427792743dc91c467"
+  integrity sha512-SrySBOJeMjLe4l1Cy6s8GUyOwOV6QYgnO1aY2t5cKSzVScWMu22Pm1/h/aDaNqLUaFKWesVZDgbPaoPan4IBHg==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/config" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/config" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.27.0.tgz#24f37bbf3833ce40de068357f084ccfda1ac8ab2"
-  integrity sha512-raoPJron5HAADWtcN0hKCVw76uoJKrM2wuakQQOudo0kuNTCPuYiVRCQZJsQfMrYEkNx/LKAKXK3nTTIF3R68Q==
+"@kiltprotocol/messaging@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.28.0-rc.1.tgz#2f9833b93c2bea37663d1bff43cfcec341d7175c"
+  integrity sha512-Q51c3W7VPYP+9ziv0EQtxF5QiKT+yKGAEN3kMBJIZnv6QK6HBMAij6625Up+9WgfI8PCWai5VOi1PScVXR3rnA==
   dependencies:
-    "@kiltprotocol/core" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
+    "@kiltprotocol/core" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
 
-"@kiltprotocol/sdk-js@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.27.0.tgz#d166c0aaffaec29519b2d4e76e08663ec2b5dc50"
-  integrity sha512-hiyjwBmEohTS+9DXCFMKsADZag5m6+7/bhdf0RUHM/olPKbtiRajZJbjEdX84QaLOb2hVrAigk7FJLYZ9g8h3g==
+"@kiltprotocol/sdk-js@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.28.0-rc.1.tgz#2f9292626510bc2e53c4271c6a37f0c02379b10e"
+  integrity sha512-GCTCapgnfEDc1fMWMwQdCQPPcFEqWIp4cbJdimS1UgEqQ1cIU9WiOQ/jbudkZ1ygqdiwZkzdPGSoHl/A3n2CTQ==
   dependencies:
-    "@kiltprotocol/chain-helpers" "0.27.0"
-    "@kiltprotocol/core" "0.27.0"
-    "@kiltprotocol/did" "0.27.0"
-    "@kiltprotocol/messaging" "0.27.0"
-    "@kiltprotocol/types" "0.27.0"
-    "@kiltprotocol/utils" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
+    "@kiltprotocol/chain-helpers" "0.28.0-rc.1"
+    "@kiltprotocol/core" "0.28.0-rc.1"
+    "@kiltprotocol/did" "0.28.0-rc.1"
+    "@kiltprotocol/messaging" "0.28.0-rc.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@kiltprotocol/utils" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
 
-"@kiltprotocol/types@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.27.0.tgz#2d2c76311d1fb22c4ec816c0fdb4955aa711421b"
-  integrity sha512-tvkIj69GkoVBmkPd+8ywkiIb4KUkS3MsaMsQlONRxQztxRPk3WkBsXjj8Ta4ss4omlo0ge4i3SdFWISyiLBrrw==
+"@kiltprotocol/types@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.28.0-rc.1.tgz#0a9ffc43f28d6e15f2963037211f1f7b24cbf470"
+  integrity sha512-6OXxWOn3TAjb7SQ4uiDpFPp9/cu3Kbna/hUsg2VKUee4Rcak5KpBWSBjZ9gIk0/wLiEtg/S8Bfb3AgS22jJV8Q==
   dependencies:
-    "@polkadot/api" "^7.10.1"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
+    "@polkadot/api" "^8.0.0"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
     tweetnacl "^1.0.3"
 
-"@kiltprotocol/utils@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.27.0.tgz#be5dbfe570669efc23ea59c12abed4882efea929"
-  integrity sha512-x43mAQ95Ee/fDBNd009vJgdB4bDaXv9Yn/PXrcrmvq6e5ZQDOD/mgDtPqmr5nTsBgdkve5x6/wX27l8fFocw7g==
+"@kiltprotocol/utils@0.28.0-rc.1":
+  version "0.28.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.28.0-rc.1.tgz#691ec275a310fb204bf81860101b87f44d9e8884"
+  integrity sha512-T2whvggOpgK6D5TkNO8MM09+5vL3TEVksQ0RsfcNgLw/VkDdwTlV4MI8pIGKfH9L/1xR9g6mvv3TfXztoBznOw==
   dependencies:
-    "@kiltprotocol/types" "0.27.0"
-    "@polkadot/api-augment" "^7.10.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "^7.10.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@kiltprotocol/types" "0.28.0-rc.1"
+    "@polkadot/api-augment" "^8.0.0"
+    "@polkadot/keyring" "^9.0.0"
+    "@polkadot/types" "^8.0.0"
+    "@polkadot/util" "^9.0.0"
+    "@polkadot/util-crypto" "^9.0.0"
     tweetnacl "^1.0.3"
     uuid "^8.1.0"
 
-"@noble/hashes@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.0.0.tgz#d5e38bfbdaba174805a4e649f13be9a9ed3351ae"
-  integrity sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg==
+"@noble/hashes@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.1.tgz#c056d9b7166c1e7387a7453c2aff199bf7d88e5f"
+  integrity sha512-Lkp9+NijmV7eSVZqiUvt3UCuuHeJpUVmRrvh430gyJjJiuJMqkeHf6/A9lQ/smmbWV/0spDeJscscPzyB4waZg==
 
-"@noble/secp256k1@1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.5.2.tgz#40399e4fba54f588fda14fc03a4499044fdcab24"
-  integrity sha512-5mzA40W2q55VCRuC9XzmkiEnODdY0c5a7qsK2QcOfI5/MuVQyBaWGQyE6YOEF7kDwp+tDVWGsCDVJUME+wsWWw==
+"@noble/secp256k1@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.0.tgz#602afbbfcfb7e169210469b697365ef740d7e930"
+  integrity sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -213,311 +213,363 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@polkadot/api-augment@7.11.1", "@polkadot/api-augment@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-7.11.1.tgz#9866afe3281ae8371c8c645e73e848bac1f6fcd3"
-  integrity sha512-CqtmRZsr7va45r/wnsH+NZMqPyUQv46fmiHxt5gq6NC4p0ziDEVVDDHLlABx5RhQzCvdiBAccZ/X8DyMCFFGEA==
+"@polkadot/api-augment@8.9.1", "@polkadot/api-augment@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-8.9.1.tgz#25b0997ccf3d1df4641123e0d9ec29e8fb03ef62"
+  integrity sha512-yobYURNgoZcZD3QJmE34n3ZcEEUtsiivquckxjJMXnHJv3zahMyJh75tCNAXjzWn+e+SqKTVlgCpLXYlC1HJPQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/api-base" "7.11.1"
-    "@polkadot/rpc-augment" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-augment" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/api-base@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-7.11.1.tgz#fb27a7c33808a8f6542b322ffb3c6702a9e15ea8"
-  integrity sha512-MATI9tm0x3rRlipLMevWzJ4cGvMyrUGyOfwjMg3Z67U7atZgZ93LzowjzDcvSgFVM14d1tBOVWBKkCKnk7C6Zg==
+"@polkadot/api-base@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-8.9.1.tgz#e0013bbb8e72678a4eecdfb880854b2e30c840d5"
+  integrity sha512-2OpS9ArZSuUu9vg2Y5DdK7r1iB1Bjx9e+6qerPGry8um+jI+EsHJESylw5OUrR2DxvtW3Ilrk4YvYpQPa9OB4w==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/api-derive@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-7.11.1.tgz#ede6119577b08d6c94767551dc6ad17c6be64149"
-  integrity sha512-py7pqs5mLaKPNDvRZ7BcUC7obsbLIuzJT/kZFiGzJXmaObSzU2lJkGD7fV34QlpmGP+Bqb4KtlhtY+Tnq33C0w==
+"@polkadot/api-derive@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-8.9.1.tgz#d701c98db27b86dceac6d3e737f0cab4f9731045"
+  integrity sha512-zOuNK1tApg3iEC5N4yiOTaMKUykk4tkNU1htcnotOxflgdhYUi22l0JuCrEtrnG6TE2ZH8z1VQA/jK0MbLfC3A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/api" "7.11.1"
-    "@polkadot/api-augment" "7.11.1"
-    "@polkadot/api-base" "7.11.1"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api" "8.9.1"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/api@7.11.1", "@polkadot/api@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-7.11.1.tgz#0aeb86319a14a9a2a071476e6a47ee3d6b8e116c"
-  integrity sha512-VTrhVuSJrWhIww1ofYPd7EhJd1UwKntfdPNRuy/abfb6GPzYCglKV6Sze3CsbI2KawC5oo1K7Ffrdf/lJy81kg==
+"@polkadot/api@8.9.1", "@polkadot/api@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-8.9.1.tgz#c35c5d583845a5d67edfa8c3579bad143f65bcd6"
+  integrity sha512-UwQ5hWPHruqnBO2hriaPhGaOwaWZx9MVECWFJzVs0ZuhKDge9jyBp+JXud/Ly/+8VbeokYUB0DSZG/gTAO5+vg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/api-augment" "7.11.1"
-    "@polkadot/api-base" "7.11.1"
-    "@polkadot/api-derive" "7.11.1"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/rpc-augment" "7.11.1"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/rpc-provider" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-augment" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/types-create" "7.11.1"
-    "@polkadot/types-known" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/api-derive" "8.9.1"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/types-known" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
     eventemitter3 "^4.0.7"
-    rxjs "^7.5.4"
+    rxjs "^7.5.5"
 
-"@polkadot/keyring@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-8.4.1.tgz#71098121c60a05e1ad33653fcc521c52f22ad1b8"
-  integrity sha512-0qfS7qikUxhe6LEdCOcMRdCxEa26inJ5aSUWaf5dXy+dgy9VJiov6uXAbXdAd1UHpDvr9hvw94FX+hXsJ7Vsyw==
+"@polkadot/keyring@^9.0.0", "@polkadot/keyring@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-9.5.1.tgz#3b0851f8fffe489f1b6020e69dc9a3a8e5696172"
+  integrity sha512-ixv2lq1zNzYa+GqZQTzcraNw5ZrTTK+2/sqfeMOIr7gBGk0UCALuK0NCvTRAUtQK1RT2psBkkm2lr/rrNCeK+A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "8.4.1"
-    "@polkadot/util-crypto" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/util-crypto" "9.5.1"
 
-"@polkadot/networks@8.4.1", "@polkadot/networks@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-8.4.1.tgz#c22585edb38f5ae0a329a1f471577d8b35bf64e4"
-  integrity sha512-YFY3fPLbc1Uz9zsX4TOzjY/FF09nABMgrMkvqddrVbSgo71NvoBv3Gqw3mKV/7bX1Gzk1ODfvTzamdpsKEWSnA==
+"@polkadot/networks@9.5.1", "@polkadot/networks@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-9.5.1.tgz#876c6cf8915a47e6ace81139197f8b0d36adb362"
+  integrity sha512-1q9jm7NLk1ZMqFJL+kYkpn1phEO+N0d5LU81ropjYf0hC9boBAya4Zqvv3DwasPuLp6qaj4r0nrfzmkP5xHKZQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "8.4.1"
-    "@substrate/ss58-registry" "^1.14.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@substrate/ss58-registry" "^1.22.0"
 
-"@polkadot/rpc-augment@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-7.11.1.tgz#c77bbdae20e3933ddd2d8eea243a215e35a6861f"
-  integrity sha512-cP/g6dM5Rmdeno+sOi/PBvAEycRoi/UI1MOKb0lVhlFJayw/uyGOhHtPKOnLh2fyDJ/q66HO3pu6aem3ORFwhQ==
+"@polkadot/rpc-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-8.9.1.tgz#644061c68a9a2abe7f3574ab74b10652acae5707"
+  integrity sha512-6TtZPVjvjcPy3w4lmcNu3MTU1h2YLkZBVNwUZFnZPhALc9qBy9ZcvkMODLPfD+mj+i8Fcfn4b7Ypj+sNqXFxUQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/rpc-core" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/rpc-core@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-7.11.1.tgz#079f2c70e09015d01bfec92f06993a5538399072"
-  integrity sha512-Bp71BwOSPT4/xmYWn9e9/ikGKYYmltbceVwa0MJiuKI0Xd5YntjtJVov17Fqlt+eddkLGt74750paykvHDJWWQ==
+"@polkadot/rpc-core@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-8.9.1.tgz#79392d2a1d1d5e93549cd0f7fae7f0d71a6fb79d"
+  integrity sha512-+mAkpxIX2kIovnIIf8uxqjXqPA/7LaeysfIPi8VGrVB3IqvLEaT2rWtCMRSFkBEZwYI7vP7PrAw9co6MMkXlUw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/rpc-augment" "7.11.1"
-    "@polkadot/rpc-provider" "7.11.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/rpc-provider@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-7.11.1.tgz#f0cf70c4fa3b69fb96aafbed07f8d5725db9cca8"
-  integrity sha512-07Mg+r9swMjNISDK8ntDI5gFZU8rtHeoB27/qQwZzcWugogva8rNhaInBikZPKlF7yxM6l2VMaQnOziKUNsnRw==
+"@polkadot/rpc-provider@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-8.9.1.tgz#1e6e8e6218bb0fe59dd673acb9198bf12acf6625"
+  integrity sha512-XunL29pi464VB6AJGuvVzTnCtk4y5KBwgBIC/S4YMdqi+l2ujXZOFM2WBnbiV+YhB7FEXmbYR8NsKAe/DSb85A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-support" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    "@polkadot/x-fetch" "^8.4.1"
-    "@polkadot/x-global" "^8.4.1"
-    "@polkadot/x-ws" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-support" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    "@polkadot/x-fetch" "^9.5.1"
+    "@polkadot/x-global" "^9.5.1"
+    "@polkadot/x-ws" "^9.5.1"
+    "@substrate/connect" "0.7.6"
     eventemitter3 "^4.0.7"
-    mock-socket "^9.1.2"
-    nock "^13.2.4"
+    mock-socket "^9.1.5"
+    nock "^13.2.6"
 
-"@polkadot/types-augment@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-7.11.1.tgz#2c56779dbd1cff509609db912fcc2575e0983828"
-  integrity sha512-jCnZ/eMkLaqSKl5q4JwBxslhAaJSSNHt04reZRs1i2jlC2UVgiFN1Rr5GJmHYAwDPoFcge/rAm6bckfhXUIdOw==
+"@polkadot/types-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-8.9.1.tgz#ff4880471eba038f8b28e412b7d8d1f500d46cf9"
+  integrity sha512-kfSioIpB8krtNgIANN8QCik+uBFmxGACEq84oxiqbKc2BfTXzcqQ7jkmslXeEqb9IsQ9rpaa3fkvyoLQNLqXgA==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-codec@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-7.11.1.tgz#4cfcd8ab81f6ba510a984c08eb11861b33acab38"
-  integrity sha512-rDM/FYcnou2Chy+urd7U41lcjM6jWUEUydyP9NuTOSAamCGtH0eKw52GURKTsKTT5r8wJdPMKv/yNxs1i+l5Lw==
+"@polkadot/types-codec@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-8.9.1.tgz#8fbf3ade7a87b716937b7f37fd43b8a46ba12c4d"
+  integrity sha512-bboHpTwvHooTdITsmJ5IqAyZDuONZaVs6xC3iRbE9SIHD4kUpivlTc+Rvk91EcQclFo5IUKvNrX4BrOx8Y/YnQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-create@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-7.11.1.tgz#878b5bdf278ca9456195980aa91957979a4e9342"
-  integrity sha512-nVYaJC/IDsM4WM9WGjAI7qQ9scPSlBqqzwqLdvXCJeq3trOTt68x39DD0zp0hzJ/7MeXjPToDDWjpAF0B9mWSQ==
+"@polkadot/types-create@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-8.9.1.tgz#ed365812b522fcc7984aa24cf7cbeeb0cdf20e34"
+  integrity sha512-q7er671QXYcmG4gkZvtKpES7QV013w36s8VT947aT3GDzlGZDQQKNKpELyi7K1sgWjQyrL3/0cTKhP8taAjWPQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-known@7.11.1", "@polkadot/types-known@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-7.11.1.tgz#55c42aae31813360ea54e438a761b0c48392f148"
-  integrity sha512-BBqQxG7I+wUjeLby1u5p9aSoZ5Vy0oCwmm/aKN64JH9vBEz1OOA0pRdcCooGCG/884Wb5pRpacWTepQMQkOTLw==
+"@polkadot/types-known@8.9.1", "@polkadot/types-known@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-8.9.1.tgz#019ab25b048f157659cf6141c3d8483c28af0123"
+  integrity sha512-y5Fvo7TM9DjM/CNQbQsR78O5LP3CuBbQY90yA2APwqZNn/dilTxWIGrxtPzTG9QCZJyhMN+EZdKUo51brKRI/g==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/networks" "^8.4.1"
-    "@polkadot/types" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/types-create" "7.11.1"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/networks" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-support@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-7.11.1.tgz#509d942c8a9c0670a20b77fc1c98c97b7151b75e"
-  integrity sha512-pJmDUHK7DOO6mjpntxq9Lq0tjvqwc15FrrrNbuENgRiOueRqcAlzv+V80wdzoIBUwINgKphtpzu+rdQIYsVVQg==
+"@polkadot/types-support@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-8.9.1.tgz#84d023945feddc15f60b8cb1a36abe2edfed4a23"
+  integrity sha512-t3HJc8o68LWvhEy63PRZQxCL4T7sSsrLm7+rpkfeJAEC1DXeFF85FwE2U+YKa3+Z3NuMv2e4DV2jnIZe9XRtHQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/util" "^8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types@7.11.1", "@polkadot/types@^7.10.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-7.11.1.tgz#aefdd0efa98b43ebf516947a845e12fc5d63e9ae"
-  integrity sha512-jxVrxIbsSfH9xK1Q3vaCfJmbkm0OlvoXz0GxdP5RJ7dQnxlNYWQUXanFkKebbRL8gSEs1wSRVccil/TSH65Nvg==
+"@polkadot/types@8.9.1", "@polkadot/types@^8.0.0":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-8.9.1.tgz#e5bf1cef79d8c305faa8691c62dd3d4be9baed53"
+  integrity sha512-h43/aPzk+ta0MzzGQz3DiGtearttHxZr08xOdtU5GctI6u9MXm0n0w74clciLpIGu5CI+QxYN3oQ8/5WXTukMw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/keyring" "^8.4.1"
-    "@polkadot/types-augment" "7.11.1"
-    "@polkadot/types-codec" "7.11.1"
-    "@polkadot/types-create" "7.11.1"
-    "@polkadot/util" "^8.4.1"
-    "@polkadot/util-crypto" "^8.4.1"
-    rxjs "^7.5.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    rxjs "^7.5.5"
 
-"@polkadot/util-crypto@8.4.1", "@polkadot/util-crypto@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-8.4.1.tgz#41ff754dc995b681913fc0a484bb0d309221a703"
-  integrity sha512-mWjp83aIWw+EhKN9RkUDmubXibo25q5yHJl4BGm2gT71yTZcABB7q1SGfpDqLH9AB3eXJiutqhC4L3SH7YZ+6Q==
+"@polkadot/util-crypto@9.5.1", "@polkadot/util-crypto@^9.0.0", "@polkadot/util-crypto@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-9.5.1.tgz#f69bdccd7043620c9bd905b169ec50bf97bf6ffb"
+  integrity sha512-4YwJJ2/mXx3PXTy4WLekQOo1MlDtQzYgTZsjOagi3Uz3Q/ITvS+/iu6eF/H6Tz0uEQjwX6t9tsMkM5FWk/XoGg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@noble/hashes" "1.0.0"
-    "@noble/secp256k1" "1.5.2"
-    "@polkadot/networks" "8.4.1"
-    "@polkadot/util" "8.4.1"
-    "@polkadot/wasm-crypto" "^4.5.1"
-    "@polkadot/x-bigint" "8.4.1"
-    "@polkadot/x-randomvalues" "8.4.1"
-    "@scure/base" "1.0.0"
+    "@babel/runtime" "^7.18.3"
+    "@noble/hashes" "1.1.1"
+    "@noble/secp256k1" "1.6.0"
+    "@polkadot/networks" "9.5.1"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/wasm-crypto" "^6.1.1"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-randomvalues" "9.5.1"
+    "@scure/base" "1.1.1"
     ed2curve "^0.3.0"
     tweetnacl "^1.0.3"
 
-"@polkadot/util@8.4.1", "@polkadot/util@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-8.4.1.tgz#b84835c55585c8b5fc5608a99aa62ac815292ae7"
-  integrity sha512-8+wqHgFbFWI5TfrvtcL888w0nWvFpbTTYIcbpEw+zYGp3n1YZTAMMP26bXWAaQX5AttxynJRij7JP3ySxYY1fg==
+"@polkadot/util@9.5.1", "@polkadot/util@^9.0.0", "@polkadot/util@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-9.5.1.tgz#b9e0b8cb0d6f1fd86e1a39a843ac8defeb6d5c9f"
+  integrity sha512-cI2ar15vkoXjs//YNn1yT5eUdK7jF32XNw3Oc6YJ2qEpenwy30c3BUQJOiqW7J6UBYLYll5O5y0ejv6LQoSFBQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-bigint" "8.4.1"
-    "@polkadot/x-global" "8.4.1"
-    "@polkadot/x-textdecoder" "8.4.1"
-    "@polkadot/x-textencoder" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-global" "9.5.1"
+    "@polkadot/x-textdecoder" "9.5.1"
+    "@polkadot/x-textencoder" "9.5.1"
     "@types/bn.js" "^5.1.0"
-    bn.js "^5.2.0"
+    bn.js "^5.2.1"
     ip-regex "^4.3.0"
 
-"@polkadot/wasm-crypto-asmjs@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.5.1.tgz#e1025a49e106db11d1187caf65f56c960ea2ad2b"
-  integrity sha512-DOdRiWhxVvmqTvp+E9z1j+Yr0zDOGsDvqnT/eNw0Dl1FVUOImsEa7FKns/urASmcxCVEE1jtUWSnij29jrORMQ==
+"@polkadot/wasm-bridge@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-bridge/-/wasm-bridge-6.1.1.tgz#9342f2b3c139df72fa45c8491b348f8ebbfa57fa"
+  integrity sha512-Cy0k00VCu+HWxie+nn9GWPlSPdiZl8Id8ulSGA2FKET0jIbffmOo4e1E2FXNucfR1UPEpqov5BCF9T5YxEXZDg==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.17.9"
 
-"@polkadot/wasm-crypto-wasm@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.5.1.tgz#063a58ff7ddd939b7886a6a238109a8d2c416e46"
-  integrity sha512-hPwke85HxpgG/RAlwdCE8u5w7bThvWg399mlB+XjogXMxOUWBZSgq2XYbgzROUXx27inK9nStF4Pnc4zJnqs9A==
+"@polkadot/wasm-crypto-asmjs@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.1.1.tgz#6d09045679120b43fbfa435b29c3690d1f788ebb"
+  integrity sha512-gG4FStVumkyRNH7WcTB+hn3EEwCssJhQyi4B1BOUt+eYYmw9xJdzIhqjzSd9b/yF2e5sRaAzfnMj2srGufsE6A==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.17.9"
 
-"@polkadot/wasm-crypto@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.5.1.tgz#e1ac6d846a0ad8e991cec128994524183ef6e8fd"
-  integrity sha512-Cr21ais3Kq3aedIHZ3J1tjgeD/+K8FCiwEawr0oRywNBSJR8wyuZMePs4swR/6xm8wbBkpqoBVHz/UQHqqQJmA==
+"@polkadot/wasm-crypto-init@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.1.1.tgz#73731071bea9b4e22b380d75099da9dc683fadf5"
+  integrity sha512-rbBm/9FOOUjISL4gGNokjcKy2X+Af6Chaet4zlabatpImtPIAK26B2UUBGoaRUnvl/w6K3+GwBL4LuBC+CvzFw==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/wasm-crypto-asmjs" "^4.5.1"
-    "@polkadot/wasm-crypto-wasm" "^4.5.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-bridge" "6.1.1"
+    "@polkadot/wasm-crypto-asmjs" "6.1.1"
+    "@polkadot/wasm-crypto-wasm" "6.1.1"
 
-"@polkadot/x-bigint@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-8.4.1.tgz#d3ccddd26cdc5413f5c722d8c53ec523299e3ff1"
-  integrity sha512-QVP0UMoM0nBD998s3ESeaoSiVMEnHK3x0CCqocKO4l7ADNw8lfWdDG7Bb0+ymNaFYGz2KgEWxkN0VhNEnXzo0w==
+"@polkadot/wasm-crypto-wasm@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.1.1.tgz#3fdc8f1280710e4d68112544b2473e811c389a2a"
+  integrity sha512-zkz5Ct4KfTBT+YNEA5qbsHhTV58/FAxDave8wYIOaW4TrBnFPPs+J0WBWlGFertgIhPkvjFnQC/xzRyhet9prg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-util" "6.1.1"
 
-"@polkadot/x-fetch@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-8.4.1.tgz#7254cdb70b61aea79debd7d0c9ae5e126f78d90d"
-  integrity sha512-DPkgXZYt1B4xCzEw/3hxRc4/lR+NEr/b/GYijSPM8UsVoEKqHWTx2qCXrxvmKh1WD9reQ+oUACPVjRcBz5bs+g==
+"@polkadot/wasm-crypto@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-6.1.1.tgz#8e2c2d64d24eeaa78eb0b74ea1c438b7bc704176"
+  integrity sha512-hv9RCbMYtgjCy7+FKZFnO2Afu/whax9sk6udnZqGRBRiwaNagtyliWZGrKNGvaXMIO0VyaY4jWUwSzUgPrLu1A==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
-    "@types/node-fetch" "^2.5.12"
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-bridge" "6.1.1"
+    "@polkadot/wasm-crypto-asmjs" "6.1.1"
+    "@polkadot/wasm-crypto-init" "6.1.1"
+    "@polkadot/wasm-crypto-wasm" "6.1.1"
+    "@polkadot/wasm-util" "6.1.1"
+
+"@polkadot/wasm-util@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-util/-/wasm-util-6.1.1.tgz#58a566aba68f90d2a701c78ad49a1a9521b17f5b"
+  integrity sha512-DgpLoFXMT53UKcfZ8eT2GkJlJAOh89AWO+TP6a6qeZQpvXVe5f1yR45WQpkZlgZyUP+/19+kY56GK0pQxfslqg==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
+"@polkadot/x-bigint@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-9.5.1.tgz#d5d98aaa6b3de560eea23df9f696903f2e2dcf7c"
+  integrity sha512-rTp7j3KvCy8vANRoaW6j0pCQdLc/eed6uSRXoxh3z1buJhw460/Q/hJ0Bey6fyeNSDzIwFk4SGwf/Gzf+kS1vQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+
+"@polkadot/x-fetch@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-9.5.1.tgz#dda5f36de656a5db2c81a81245ad5059f95879a9"
+  integrity sha512-jMWpDVE4CyH+vVuONmvcKlJJnsRqmglmJTppsl+38JTnGL2FbELn2q92N8b5uTxmPP0lf+QTn1THXnkWvG7Ojw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+    "@types/node-fetch" "^2.6.2"
     node-fetch "^2.6.7"
 
-"@polkadot/x-global@8.4.1", "@polkadot/x-global@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-8.4.1.tgz#61def1f5962001200c17b9fde92f6837736b3c55"
-  integrity sha512-MQs89LKQrJwiXjV7dY2kDOPNaiWrwaQ/Fzg93ycB2xMCclRV1jRFRhnhTPJ8Ao79lhCCoazd7pXIyFgfifxdqg==
+"@polkadot/x-global@9.5.1", "@polkadot/x-global@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-9.5.1.tgz#a78e109ca95f5ba5e9c501a2106a9b3acfe3a682"
+  integrity sha512-asG5YlW1K3f4YjyuZ+HrbF9H5d78i5v9+7Bh+9gD+sVfB3KhqwVYZB+wzOaJkPp6lwUbBA9OBHFCVBqpR3wBJw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
+    "@babel/runtime" "^7.18.3"
 
-"@polkadot/x-randomvalues@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-8.4.1.tgz#4488d2d6b982e7b2ecafc573cd25e3f1e85a512c"
-  integrity sha512-1dRIFIib4RzyVo0k5oMLuxqSuZEV6UVvvN+jJw9G/9P1ggZtHjM1KwoFcyHgvpk2RWTB9eJZFemwSvQTpdmSJw==
+"@polkadot/x-randomvalues@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-9.5.1.tgz#e647554f7b34d4073e1bc60d8b81163d5f75f523"
+  integrity sha512-NFvG//NsBjFP01dEtQATNPn5lSAZwh6jkkUXG2rHlgvW6k8nVJ0aJPvO5MlgItgS5Ry2F88AIiSsO3cfoTpszg==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-textdecoder@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-8.4.1.tgz#5a227006d183f5ec3a8a331ca38e4969d24c4a97"
-  integrity sha512-qbSXyR2KvE1bO6QGsxWU3Yrx5e70rX2lwv0MHG++MyyNaDoBM3hjx14lF911bYRWXR6MW4eZ+0Nakn0oM5uSKw==
+"@polkadot/x-textdecoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-9.5.1.tgz#13c1b48b12d350b635de385c8a0e2be14210b620"
+  integrity sha512-bY0J3Tov5y4oZi8qB/UtoEYCSgo5sDiiOa3Wmgen09LfB4gXJhWFGJSmcZqHERXCdEcmZojdbHTvOGSeYM9U1w==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-textencoder@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-8.4.1.tgz#ea01733ce6b80821bf8af943a1d98878a9150af5"
-  integrity sha512-1UYuckNOk6NUk70Y/SGbK8oyGbqPlrny1x2OWoK/BT3/tyL2xKVV5TlXDOiFrX1PChbskXye5M8blCTYikFiJg==
+"@polkadot/x-textencoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-9.5.1.tgz#76d79d07bb81e9cc7eff97043eae82c39189d8d9"
+  integrity sha512-zt121nqxiudMeZnanpnfWhCE0SOTcVRqn/atqO59us/yf6LMTf23mgd7P4795TgJwXOUcui4fhm/g/VcpsLq9Q==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-ws@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-8.4.1.tgz#502fc034588cd81ed9dc0301ca70197bf3d78799"
-  integrity sha512-u9rsJdVrBkSARy8BhJPho1yMMBSiI/Z/W8ZQRr1I28/QOwl02VYktFpFWWrhkBHsL9JlZ0wfnyKBPXrw8Wp2Vw==
+"@polkadot/x-ws@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-9.5.1.tgz#990d86c8bc54d6fe00c6ff16f341b9304dd89164"
+  integrity sha512-d91Hf7p9+mWqSvx+lZr0f7eVkHXGzNqvQnXYAizU1HE1HHl5gLixPKoGldTKrYhvV30OwKKDJChKHzvQL6nVdQ==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@polkadot/x-global" "8.4.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
     "@types/websocket" "^1.0.5"
     websocket "^1.0.34"
 
-"@scure/base@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
-  integrity sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==
+"@scure/base@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
-"@substrate/ss58-registry@^1.14.0":
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.16.0.tgz#100d174f38999cfba34ca02b812257a75c3fe952"
-  integrity sha512-z88145A9NE0mnDbIYRP1SlHndDtm6Jd1cRnG2InRCA/M7UprFRc0zrtaTWj1KBHfcVc2uYUMggGXuenQPBQ8yQ==
+"@substrate/connect-extension-protocol@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.0.tgz#d452beda84b3ebfcf0e88592a4695e729a91e858"
+  integrity sha512-nFVuKdp71hMd/MGlllAOh+a2hAqt8m6J2G0aSsS/RcALZexxF9jodbFc62ni8RDtJboeOfXAHhenYOANvJKPIg==
+
+"@substrate/connect@0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@substrate/connect/-/connect-0.7.6.tgz#4b1cca6bf9c0e8be93f6f6a4eeb6684993f5dc18"
+  integrity sha512-PHizR91CbjC5bzUwgYUZJrbOyoraCS1QqoxkFHteZ/0vkXDKyuzoixobDaITJqq6wSTeM8ZSjuOn9u/3q7F5+A==
+  dependencies:
+    "@substrate/connect-extension-protocol" "^1.0.0"
+    "@substrate/smoldot-light" "0.6.19"
+    eventemitter3 "^4.0.7"
+
+"@substrate/smoldot-light@0.6.19":
+  version "0.6.19"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.6.19.tgz#13e897ca9839aecb0dac4ce079ff1cca1dc54cc0"
+  integrity sha512-Xi+v1cdURhTwx7NH+9fa1U9m7VGP61GvB6qwev9HrZXlGbQiUIvySxPlH/LMsq3mwgiRYkokPhcaZEHufY7Urg==
+  dependencies:
+    buffer "^6.0.1"
+    pako "^2.0.4"
+    websocket "^1.0.32"
+
+"@substrate/ss58-registry@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.22.0.tgz#d115bc5dcab8c0f5800e05e4ef265949042b13ec"
+  integrity sha512-IKqrPY0B3AeIXEc5/JGgEhPZLy+SmVyQf+k0SIGcNSTqt1GLI3gQFEOFwSScJdem+iYZQUrn6YPPxC3TpdSC3A==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -556,10 +608,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node-fetch@^2.5.12":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
-  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -745,10 +797,15 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bn.js@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
-  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -764,6 +821,14 @@ braces@^3.0.1:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+buffer@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bufferutil@^4.0.1:
   version "4.0.6"
@@ -1424,6 +1489,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -1636,10 +1706,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -1690,10 +1760,10 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mock-socket@^9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.2.tgz#cce6cf2193aada937ba41de3288c5c1922fbd571"
-  integrity sha512-XKZkCnQ9ISOlTnaPg4LYYSMj7+6i78HyadYzLA5JM4465ibLdjappZD9Csnqc3Tfzep/eEK/LCJ29BTaLHoB1A==
+mock-socket@^9.1.5:
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.5.tgz#2c4e44922ad556843b6dfe09d14ed8041fa2cdeb"
+  integrity sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg==
 
 ms@2.0.0:
   version "2.0.0"
@@ -1720,14 +1790,14 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
-nock@^13.2.4:
-  version "13.2.4"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.4.tgz#43a309d93143ee5cdcca91358614e7bde56d20e1"
-  integrity sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==
+nock@^13.2.6:
+  version "13.2.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.7.tgz#c93933b61df42f4f4b3a07fde946a4e209c0c168"
+  integrity sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
-    lodash.set "^4.3.2"
+    lodash "^4.17.21"
     propagate "^2.0.0"
 
 node-fetch@^2.6.7:
@@ -1813,6 +1883,11 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+pako@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
+  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -1926,7 +2001,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.5.4:
+rxjs@^7.5.5:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
@@ -2215,7 +2290,7 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
-websocket@^1.0.34:
+websocket@^1.0.32, websocket@^1.0.34:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
   integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==

--- a/docs/develop/01_sdk/04_integrate/01_nodejs.md
+++ b/docs/develop/01_sdk/04_integrate/01_nodejs.md
@@ -23,7 +23,7 @@ Have a look at these example `package.json` and `index.js` files for reference:
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.27.0"
+    "@kiltprotocol/sdk-js": "0.28.0"
   }
 }
 ```

--- a/docs/develop/01_sdk/04_integrate/04_vitejs.md
+++ b/docs/develop/01_sdk/04_integrate/04_vitejs.md
@@ -18,7 +18,7 @@ Bootstrap using the template of your choice and install KILT + NodeJS polyfills:
 ```bash
 yarn create vite my-app --template react-ts
 cd my-app
-yarn add @kiltprotocol/sdk-js@0.27.0
+yarn add @kiltprotocol/sdk-js@0.28.0
 yarn add --dev @esbuild-plugins/node-globals-polyfill
 yarn add --dev @esbuild-plugins/node-modules-polyfill
 ```

--- a/docs/develop/03_workshop/01_welcome.md
+++ b/docs/develop/03_workshop/01_welcome.md
@@ -4,7 +4,7 @@ title: 👋🏻 Welcome
 ---
 
 <!-- When updating this version also update 02_setup.md! -->
-SDK version **0.27.0**.
+SDK version **0.28.0**.
 
 :::info What you can expect
 

--- a/docs/develop/03_workshop/02_setup.md
+++ b/docs/develop/03_workshop/02_setup.md
@@ -20,7 +20,7 @@ Navigate into your newly created folder `kilt-rocks`, initialize the project and
 <!-- When updating this version also update 00-welcome.md! -->
 ```bash npm2yarn
 npm init -y
-npm install @kiltprotocol/sdk-js@0.27.0 dotenv ts-node typescript
+npm install @kiltprotocol/sdk-js@0.28.0 dotenv ts-node typescript
 ```
 
 ## Project Folder


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2055 and fixes https://github.com/KILTprotocol/ticket/issues/2063.

It fails because of lack of retro-compatibility. Fixed in https://github.com/KILTprotocol/sdk-js/pull/559.

## Checklist

- [x] Update SDK mentions to 0.28.0 from 0.27.0 in READMEs when the new official version is out
- [x] Wait for 0.28 to be released