### PR TITLE
ci:trigger gh-release when test-code-examples workflow is sucessful c…

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,26 +1,15 @@
 name: deploy
 
 on:
-  pull_request:
-    branches: [master]
-  push:
-    branches: [master]
+  workflow_run:
+    workflows: [ "test-code-examples" ]
+    branches: [ master ]
+    types:
+      - completed
 
 jobs:
-  checks:
-    if: github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
-      - name: Test Build
-        run: |
-          yarn install --frozen-lockfile
-          yarn run build
   gh-release:
-    if: github.event_name != 'pull_request'
+    if: (github.event_name != 'pull_request' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
## fixes KILTProtocol/ticke #1887
Docs shall be deployed only if two conditions are met:

1. `push` envet on `master` branch
2. `test-code-examples` workflow is completed with `success`

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
