### PR TITLE
fix: prettier style script

### DIFF
--- a/code_examples/core_features/dev_setup.ts
+++ b/code_examples/core_features/dev_setup.ts
@@ -3,7 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function runAll(address: string): Promise<void> {
   // Connect to the blockchain
   await Kilt.init({ address })
-  
+
   const keyring = new Kilt.Utils.Keyring({
     type: 'sr25519',
     ss58Format: 38

--- a/code_examples/core_features/package.json
+++ b/code_examples/core_features/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts --format=codeframe",
     "lint:fix": "yarn lint --fix",
-    "style": "prettier --check --config .prettierrc **/*.ts",
+    "style": "prettier --check --config .prettierrc '**/*.ts'",
     "style:fix": "yarn style --write",
     "test": "ts-node run_core_features.ts"
   },

--- a/code_examples/core_features/run_core_features.ts
+++ b/code_examples/core_features/run_core_features.ts
@@ -10,25 +10,37 @@ import { randomAsU8a } from '@polkadot/util-crypto'
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 import { runAll as runAllClaiming } from './claiming'
-import { runAll as runAllDevSetup} from './dev_setup'
+import { runAll as runAllDevSetup } from './dev_setup'
 import { runAll as runAllDid } from './did'
 import { runAll as runAllGettingStarted } from './getting_started'
 import { runAll as runAllLinking } from './linking'
 import { runAll as runAllWeb3 } from './web3names'
 
-const resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.BlockchainUtils.IS_IN_BLOCK
+const resolveOn: Kilt.SubscriptionPromise.ResultEvaluator =
+  Kilt.BlockchainUtils.IS_IN_BLOCK
 const nodeAddress = 'wss://peregrine.kilt.io/parachain-public-ws'
 
-async function endowAccount(faucetAccount: KeyringPair, destinationAccount: KeyringPair['address'], amount: BN): Promise<void> {
-  console.log(`Endowing test account "${destinationAccount}" with ${Kilt.BalanceUtils.formatKiltBalance(amount, { decimals: 0 })}`)
-  await Kilt.Balance.getTransferTx(destinationAccount, Kilt.BalanceUtils.KILT_COIN.mul(amount), 0).
-    then((tx) =>
-      Kilt.ChainHelpers.BlockchainUtils.signAndSubmitTx(
-        tx,
-        faucetAccount,
-        { reSign: true, resolveOn }
-      )
-    )
+async function endowAccount(
+  faucetAccount: KeyringPair,
+  destinationAccount: KeyringPair['address'],
+  amount: BN
+): Promise<void> {
+  console.log(
+    `Endowing test account "${destinationAccount}" with ${Kilt.BalanceUtils.formatKiltBalance(
+      amount,
+      { decimals: 0 }
+    )}`
+  )
+  await Kilt.Balance.getTransferTx(
+    destinationAccount,
+    Kilt.BalanceUtils.KILT_COIN.mul(amount),
+    0
+  ).then((tx) =>
+    Kilt.ChainHelpers.BlockchainUtils.signAndSubmitTx(tx, faucetAccount, {
+      reSign: true,
+      resolveOn
+    })
+  )
 }
 
 async function main(): Promise<void> {

--- a/code_examples/vitejs/package.json
+++ b/code_examples/vitejs/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts --ext .tsx --format=codeframe",
     "lint:fix": "yarn lint --fix",
-    "style": "prettier --check --config .prettierrc **/*.ts{,x}",
+    "style": "prettier --check --config .prettierrc '**/*.ts{,x}'",
     "style:fix": "yarn style --write"
   },
   "dependencies": {

--- a/code_examples/workshop/package.json
+++ b/code_examples/workshop/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts --format=codeframe",
     "lint:fix": "yarn lint --fix",
-    "style": "prettier --check --config .prettierrc **/*.ts",
+    "style": "prettier --check --config .prettierrc '**/*.ts'",
     "style:fix": "yarn style --write",
     "test": "ts-node test.ts"
   },

--- a/code_examples/workshop/test.ts
+++ b/code_examples/workshop/test.ts
@@ -16,24 +16,26 @@ async function testWorkshop() {
   process.env.WSS_ADDRESS = 'wss://peregrine.kilt.io/parachain-public-ws'
 
   // setup attester account
-  const { account: attesterAccount, mnemonic: attesterMnemonic } = await generateAccount()
+  const { account: attesterAccount, mnemonic: attesterMnemonic } =
+    await generateAccount()
   process.env.ATTESTER_MNEMONIC = attesterMnemonic
   process.env.ATTESTER_ADDRESS = attesterAccount.address
 
   // setup claimer & create attestation request
-  const { lightDid: claimerDid, mnemonic: claimerMnemonic } = await generateLightDid()
+  const { lightDid: claimerDid, mnemonic: claimerMnemonic } =
+    await generateLightDid()
   process.env.CLAIMER_DID_URI = claimerDid.uri
   process.env.CLAIMER_MNEMONIC = claimerMnemonic
 
   await generateRequest({
     age: 27,
-    name: 'Karl',
+    name: 'Karl'
   })
 
   // send tokens to attester...
   const keyring = new Kilt.Utils.Keyring({
     type: 'sr25519',
-    ss58Format: 38,
+    ss58Format: 38
   })
 
   const faucetSeed = process.env[SEED_ENV]
@@ -47,9 +49,7 @@ async function testWorkshop() {
   const faucetAccount = keyring.createFromUri(faucetSeed)
 
   await Kilt.Balance.getTransferTx(attesterAccount.address, new BN(5), 0)
-    .then((tx) =>
-      Kilt.BlockchainUtils.signAndSubmitTx(tx, faucetAccount)
-    )
+    .then((tx) => Kilt.BlockchainUtils.signAndSubmitTx(tx, faucetAccount))
     .then(() => console.log('Successfully transferred tokens'))
 
   // create attester did & ensure ctype

--- a/code_examples/workshop/verify.ts
+++ b/code_examples/workshop/verify.ts
@@ -10,7 +10,10 @@ function getChallenge(): string {
 }
 
 // verifies validity, ownership & attestation
-async function verifyPresentation(presentation: Kilt.ICredential, challenge: string): Promise<boolean> {
+async function verifyPresentation(
+  presentation: Kilt.ICredential,
+  challenge: string
+): Promise<boolean> {
   const credential = new Kilt.Credential(presentation)
 
   const isValid = await credential.verify({ challenge })
@@ -34,14 +37,19 @@ export async function verificationFlow() {
     authenticationKey: {
       publicKey: keys.authenticationKey.publicKey,
       type: Kilt.VerificationKeyType.Sr25519
-    },
+    }
   })
 
   // Verifier sends a unique challenge to the claimer 🕊
   const challenge = getChallenge()
 
   // create a presentation and send it to the verifier 🕊
-  const presentation = await createPresentation(credential, lightDid, keystore, challenge)
+  const presentation = await createPresentation(
+    credential,
+    lightDid,
+    keystore,
+    challenge
+  )
 
   // The verifier checks the presentation
   const isValid = await verifyPresentation(presentation, challenge)


### PR DESCRIPTION
## quick fix

The `yarn style` command was broken; the glob pattern needs to be quoted to work in the package script. Therefore the results of running the command directly from the console and via the package script diverged. Now style errors are detected and fixed by the style script again. 

## How to test:

See workflow run for commit 329444a49544a0e028cd6210ade3a0d4fe1ad9ba vs commit https://github.com/KILTprotocol/docs/commit/7d90277a7e43867c5e0d7377c99deef4e86bd159

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
