### PR TITLE
fix: pin the demo keystore links to 0.28.0 instead of develop

### DIFF
--- a/docs/develop/01_sdk/02_cookbook/01_dids/01_light_did_creation.md
+++ b/docs/develop/01_sdk/02_cookbook/01_dids/01_light_did_creation.md
@@ -7,8 +7,8 @@ import CodeBlock from '@theme/CodeBlock';
 import LightDidSimple from '!!raw-loader!@site/code_examples/core_features/did/01_light_did_simple.ts';
 import LightDidComplete from '!!raw-loader!@site/code_examples/core_features/did/02_light_did_complete.ts';
 
-The creation of a light DID require a keystore instance that conforms to the [Keystore interface](https://github.com/KILTprotocol/sdk-js/blob/0.28.0/packages/types/src/Keystore.ts).
-For the sake of ease of use, the SDK provides a [demo keystore](https://github.com/KILTprotocol/sdk-js/blob/0.28.0/packages/did/src/DemoKeystore/DemoKeystore.ts) which can be used to generate key pairs that are kept in memory and disappear at the end of the program execution.
+The creation of a light DID require a keystore instance that conforms to the [Keystore interface](https://github.com/KILTprotocol/sdk-js/blob/master/packages/types/src/Keystore.ts).
+For the sake of ease of use, the SDK provides a [demo keystore](https://github.com/KILTprotocol/sdk-js/blob/master/packages/did/src/DemoKeystore/DemoKeystore.ts) which can be used to generate key pairs that are kept in memory and disappear at the end of the program execution.
 
 :::warning
 Using the demo keystore in production is highly discouraged as all the keys are kept in the memory and easily retrievable by malicious actors.

--- a/docs/develop/01_sdk/02_cookbook/01_dids/01_light_did_creation.md
+++ b/docs/develop/01_sdk/02_cookbook/01_dids/01_light_did_creation.md
@@ -7,8 +7,8 @@ import CodeBlock from '@theme/CodeBlock';
 import LightDidSimple from '!!raw-loader!@site/code_examples/core_features/did/01_light_did_simple.ts';
 import LightDidComplete from '!!raw-loader!@site/code_examples/core_features/did/02_light_did_complete.ts';
 
-The creation of a light DID require a keystore instance that conforms to the [Keystore interface](https://github.com/KILTprotocol/sdk-js/blob/develop/packages/types/src/Keystore.ts).
-For the sake of ease of use, the SDK provides a [demo keystore](https://github.com/KILTprotocol/sdk-js/blob/develop/packages/did/src/DemoKeystore/DemoKeystore.ts) which can be used to generate key pairs that are kept in memory and disappear at the end of the program execution.
+The creation of a light DID require a keystore instance that conforms to the [Keystore interface](https://github.com/KILTprotocol/sdk-js/blob/0.28.0/packages/types/src/Keystore.ts).
+For the sake of ease of use, the SDK provides a [demo keystore](https://github.com/KILTprotocol/sdk-js/blob/0.28.0/packages/did/src/DemoKeystore/DemoKeystore.ts) which can be used to generate key pairs that are kept in memory and disappear at the end of the program execution.
 
 :::warning
 Using the demo keystore in production is highly discouraged as all the keys are kept in the memory and easily retrievable by malicious actors.


### PR DESCRIPTION
## fixes KILTProtocol/ticket#312

This hotfixes the broken links for the demo keystore and the keystore interface until we have better docs how its done in the next version of the SDK.

## How to test:
Please provide a brief step-by-step instruction.
If necessary provide information about dependencies (specific configuration, branches, database dumps, etc.)

- Step 1
- Step 2
- etc.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
