### PR TITLE
fix(ci): sdk release triggered workflow

### DIFF
--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -128,7 +128,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          base: develop
+          base: master
           delete-branch: true
           title: '[Chore] Update SDK version to latest'
           body: |

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -68,6 +68,27 @@ jobs:
         run: |
           yarn run ts-node run_core_features.ts
 
+  vitejs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get current package version
+        working-directory: code_examples/vitejs
+        id: kiltprotocol_sdk
+        run: echo "::set-output name=current_tag::$(grep kiltprotocol/sdk-js package.json | awk -F \" '{print $4}')"
+      - uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: '@kiltprotocol/sdk-js": "${{ steps.kiltprotocol_sdk.outputs.current_tag }}'
+          replace: '@kiltprotocol/sdk-js": "${{ github.event.client_payload.latestTag }}'
+          include: "code_examples/**"
+          exclude: "**/*.lock"
+          regex: true
+      - name: Test style conventions
+        working-directory: code_examples/vitejs
+        run: |
+          yarn install
+
   create_pull_request:
     runs-on: ubuntu-latest
     needs: [ workshop, core_features ]
@@ -97,6 +118,10 @@ jobs:
           yarn install
       - name: Regenerate yarn lock
         working-directory: code_examples/workshop
+        run: |
+          yarn install
+      - name: Regenerate yarn lock
+        working-directory: code_examples/vitejs
         run: |
           yarn install
       - name: Create Pull Request


### PR DESCRIPTION
## fixes KILTprotocol/ticket#2119
The sdk release test pipeline is broken bc someone deleted the develop branch without changing the PR target in the wf.
Also we don't refresh the lock file of the vitejs code examples.

## How to test:
I honestly don't know how to test this, but it's definitely less broken than before.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
