### PR TITLE
chore: update snippets to SDK v0.29.0-52

### DIFF
--- a/code_examples/core_features/claiming/01_create_ctype.ts
+++ b/code_examples/core_features/claiming/01_create_ctype.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function createDriversLicenseCType(
-  creator: Kilt.DidDetails,
+  creator: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain

--- a/code_examples/core_features/claiming/02_request_attestation.ts
+++ b/code_examples/core_features/claiming/02_request_attestation.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function requestAttestation(
-  claimer: Kilt.DidDetails,
+  claimer: Kilt.DidDocument,
   signCallback: Kilt.SignCallback,
   ctype: Kilt.ICType
 ): Promise<Kilt.ICredential> {

--- a/code_examples/core_features/claiming/03_create_attestation.ts
+++ b/code_examples/core_features/claiming/03_create_attestation.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function createAttestation(
-  attester: Kilt.DidDetails,
+  attester: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   credential: Kilt.ICredential,

--- a/code_examples/core_features/claiming/04_create_presentation.ts
+++ b/code_examples/core_features/claiming/04_create_presentation.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function createPresentation(
-  claimer: Kilt.DidDetails,
+  claimer: Kilt.DidDocument,
   credential: Kilt.ICredential,
   signCallback: Kilt.SignCallback,
   selectedAttributes: string[] | undefined = undefined,

--- a/code_examples/core_features/claiming/06_revoke_attestation.ts
+++ b/code_examples/core_features/claiming/06_revoke_attestation.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function revokeCredential(
-  attester: Kilt.DidDetails,
+  attester: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   credential: Kilt.ICredential,

--- a/code_examples/core_features/did/01_light_did_simple.ts
+++ b/code_examples/core_features/did/01_light_did_simple.ts
@@ -7,14 +7,14 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function createSimpleLightDid(
   keyring: Keyring,
   authenticationSeed: Uint8Array = randomAsU8a(32)
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   // Ask the keyring to generate a new keypair to use for authentication with the generated seed.
   const authKey = keyring.addFromSeed(
     authenticationSeed
   ) as Kilt.NewLightDidVerificationKey
 
   // Create a light DID from the generated authentication key.
-  const lightDID = Kilt.Did.createLightDidDetails({
+  const lightDID = Kilt.Did.createLightDidDocument({
     authentication: [authKey]
   })
   console.log(lightDID.uri)

--- a/code_examples/core_features/did/02_light_did_complete.ts
+++ b/code_examples/core_features/did/02_light_did_complete.ts
@@ -7,7 +7,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function createCompleteLightDid(
   keyring: Keyring,
   authenticationSeed: Uint8Array = randomAsU8a(32)
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   const authKey = keyring.addFromSeed(
     authenticationSeed
   ) as Kilt.NewLightDidVerificationKey
@@ -24,7 +24,7 @@ export async function createCompleteLightDid(
   ]
 
   // Create the KILT light DID with the information generated.
-  const lightDID = Kilt.Did.createLightDidDetails({
+  const lightDID = Kilt.Did.createLightDidDocument({
     authentication: [authKey],
     keyAgreement: [
       {

--- a/code_examples/core_features/did/03_light_did_migrate.ts
+++ b/code_examples/core_features/did/03_light_did_migrate.ts
@@ -1,12 +1,12 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function migrateLightDid(
-  lightDid: Kilt.DidDetails,
+  lightDid: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
     .IS_FINALIZED
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   // Generate the DID migration extrinsic.
   const migrationTx = await Kilt.Did.Chain.getStoreTx(
     lightDid,

--- a/code_examples/core_features/did/04_full_did_simple.ts
+++ b/code_examples/core_features/did/04_full_did_simple.ts
@@ -11,7 +11,7 @@ export async function createSimpleFullDid(
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
     .IS_FINALIZED
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   // Ask the keyring to generate a new keypair to use for authentication with the generated seed.
   const authKey = keyring.addFromSeed(
     authenticationSeed

--- a/code_examples/core_features/did/05_full_did_complete.ts
+++ b/code_examples/core_features/did/05_full_did_complete.ts
@@ -11,7 +11,7 @@ export async function createCompleteFullDid(
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
     .IS_FINALIZED
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   // Create the encryption key seed by hasing the provided authentication seed.
   const encryptionSeed = blake2AsU8a(authenticationSeed)
   // Create the attestation key seed by hasing the generated encryption key seed.

--- a/code_examples/core_features/did/06_full_did_update.ts
+++ b/code_examples/core_features/did/06_full_did_update.ts
@@ -6,12 +6,12 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function updateFullDid(
   keyring: Keyring,
-  fullDid: Kilt.DidDetails,
+  fullDid: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
     .IS_FINALIZED
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   // Ask the keyring to generate a new keypair to use for authentication.
   const newAuthKey = keyring.addFromSeed(
     randomAsU8a(32)

--- a/code_examples/core_features/did/07_full_did_batch.ts
+++ b/code_examples/core_features/did/07_full_did_batch.ts
@@ -23,7 +23,7 @@ function getRandomCType(): Kilt.ICType {
 export async function batchCTypeCreationExtrinsics(
   api: ApiPromise,
   submitterAccount: Kilt.KiltKeyringPair,
-  fullDid: Kilt.DidDetails,
+  fullDid: Kilt.DidDocument,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
     .IS_FINALIZED

--- a/code_examples/core_features/did/08_did_signature.ts
+++ b/code_examples/core_features/did/08_did_signature.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function generateAndVerifyDidAuthenticationSignature(
-  did: Kilt.DidDetails,
+  did: Kilt.DidDocument,
   payload: string | Uint8Array,
   signCallback: Kilt.SignCallback
 ): Promise<void> {

--- a/code_examples/core_features/did/09_full_did_delete.ts
+++ b/code_examples/core_features/did/09_full_did_delete.ts
@@ -2,7 +2,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function deleteFullDid(
   submitterAccount: Kilt.KiltKeyringPair,
-  fullDid: Kilt.DidDetails,
+  fullDid: Kilt.DidDocument,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
     .IS_FINALIZED

--- a/code_examples/core_features/getting_started/02_init_sdk.ts
+++ b/code_examples/core_features/getting_started/02_init_sdk.ts
@@ -1,5 +1,5 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function main(): Promise<void> {
-  await Kilt.init({ address: 'wss://spiritnet.kilt.io/' })
+  await Kilt.init()
 }

--- a/code_examples/core_features/getting_started/03_connect.ts
+++ b/code_examples/core_features/getting_started/03_connect.ts
@@ -1,5 +1,5 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function main(): Promise<void> {
-  await Kilt.connect()
+  await Kilt.connect('wss://spiritnet.kilt.io/')
 }

--- a/code_examples/core_features/getting_started/05_fetch_endpoints.ts
+++ b/code_examples/core_features/getting_started/05_fetch_endpoints.ts
@@ -7,7 +7,7 @@ export async function main(
   console.log(`John Doe's DID Document:`)
   console.log(JSON.stringify(johnDoeDidDocument, undefined, 2))
 
-  const endpoints = johnDoeDidDocument?.details?.service
+  const endpoints = johnDoeDidDocument?.document?.service
   if (!endpoints) {
     console.log('No endpoints for the DID.')
     return []

--- a/code_examples/core_features/linking/01_did_link.ts
+++ b/code_examples/core_features/linking/01_did_link.ts
@@ -3,7 +3,7 @@ import type { KeyringPair } from '@polkadot/keyring/types'
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function linkAccountToDid(
-  did: Kilt.DidDetails,
+  did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   linkedAccount: KeyringPair,
   signCallback: Kilt.SignCallback,

--- a/code_examples/core_features/linking/02_account_link.ts
+++ b/code_examples/core_features/linking/02_account_link.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function linkDidToAccount(
-  did: Kilt.DidDetails,
+  did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain

--- a/code_examples/core_features/linking/05_did_unlink.ts
+++ b/code_examples/core_features/linking/05_did_unlink.ts
@@ -3,7 +3,7 @@ import type { KeyringPair } from '@polkadot/keyring/types'
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function unlinkAccountFromDid(
-  did: Kilt.DidDetails,
+  did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   linkedAccountAddress: KeyringPair['address'],
   signCallback: Kilt.SignCallback,

--- a/code_examples/core_features/package.json
+++ b/code_examples/core_features/package.json
@@ -11,7 +11,7 @@
     "test": "ts-node run_core_features.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.29.0-48",
+    "@kiltprotocol/sdk-js": "0.29.0-52",
     "axios": "^0.27.2",
     "dotenv": "^16.0.0"
   },

--- a/code_examples/core_features/run_core_features.ts
+++ b/code_examples/core_features/run_core_features.ts
@@ -68,10 +68,9 @@ async function main(): Promise<void> {
   }
   await gettingStartedFlow()
 
-  await Kilt.init({ address: nodeAddress })
+  const api = await Kilt.connect(nodeAddress)
   // FIXME: Remove when used versions match
   await cryptoWaitReady()
-  const api = await Kilt.connect()
 
   const keyring = new Keyring({
     ss58Format: Kilt.Utils.ss58Format,

--- a/code_examples/core_features/run_core_features.ts
+++ b/code_examples/core_features/run_core_features.ts
@@ -45,11 +45,11 @@ async function endowAccounts(
       decimals: 0
     })} each...`
   )
-  await Kilt.Blockchain.signAndSubmitTx(
-    api.tx.utility.batchAll(transferBatch),
-    faucetAccount,
-    { resolveOn }
-  )
+  // -1 nonce makes sure that the right nonce is fetched via RPC
+  const signedBatch = await api.tx.utility
+    .batchAll(transferBatch)
+    .signAsync(faucetAccount, { nonce: -1 })
+  await Kilt.Blockchain.submitSignedTx(signedBatch, { resolveOn })
 }
 
 async function main(): Promise<void> {

--- a/code_examples/core_features/web3names/01_claim.ts
+++ b/code_examples/core_features/web3names/01_claim.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function claimWeb3Name(
-  did: Kilt.DidDetails,
+  did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   name: Kilt.Did.Web3Names.Web3Name,
   signCallback: Kilt.SignCallback,

--- a/code_examples/core_features/web3names/03_query_name_credentials.ts
+++ b/code_examples/core_features/web3names/03_query_name_credentials.ts
@@ -32,7 +32,7 @@ export async function queryPublishedCredentials(
     throw 'The DID does not exist on the KILT blockchain.'
   }
 
-  const didDetails = resolutionResult.details
+  const didDetails = resolutionResult.document
   // If no details are returned but resolutionResult is not null, the DID has been deleted.
   // This information is present in `resolutionResult.metadata.deactivated`.
   if (!didDetails) {

--- a/code_examples/core_features/web3names/04_release.ts
+++ b/code_examples/core_features/web3names/04_release.ts
@@ -1,7 +1,7 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function releaseWeb3Name(
-  did: Kilt.DidDetails,
+  did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain

--- a/code_examples/core_features/yarn.lock
+++ b/code_examples/core_features/yarn.lock
@@ -71,58 +71,58 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kiltprotocol/augment-api@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-48.tgz#6117de30d5af7a2013ad6ae83185a69dcd80d8c5"
-  integrity sha512-hGBrKwJe/0MvWfgl2PtxWoz0O+LWeHmG6NXiPDnjX2o7gdiZJyLj87my6be/QUe1yb1AZYvf7EuOoI7pxHgvRA==
+"@kiltprotocol/augment-api@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-52.tgz#2eaea02e48ed3abf92e39109d1828f3e0b57fb12"
+  integrity sha512-B+omHQIe4zIo4ZCsy39+e1YYzmdOPBWW4268u2qQQ2HiLq7YFaEQ/t0vQKL/g1xIerIg8oNfi2m03zYBumPHGA==
 
-"@kiltprotocol/chain-helpers@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-48.tgz#ee41f21866377de1b0b30b471bc4935b6e3aabc4"
-  integrity sha512-jO6Pfd2pd1Xjamyd5xKiCbGWQ6Inw9rKbYpefAD8nJWItI3GUcFZSj7/PlSAUMNXSczth6GqwGLhLowqLham4w==
+"@kiltprotocol/chain-helpers@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-52.tgz#65d267c219971291eac61d2ccd3b027249909a68"
+  integrity sha512-vXlu6JBzvEUqXsl6bc4+esVLzD2ysMhkYMerCnnWYT6gRt8CUCoUrHKrU5bVqOnPDX9LBDT2o6KuAt7PECkrlA==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/types" "^9.0.0"
 
-"@kiltprotocol/config@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-48.tgz#195071acea6fa3b830513b145300ccb5d2ee2313"
-  integrity sha512-hVsHpGWQpGipOiQGkF0AspXQUv2YzyWOJ7e53wJsRrQf+FHvxRDRhdFHqHsWF/oI2ljIZKHCWkD81a4rRaRseQ==
+"@kiltprotocol/config@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-52.tgz#b6c37df57b1a98334c22a366165284c58751d935"
+  integrity sha512-1azuBiv5h5IAfCpACWNY7lmYrOAGzOK3bIno5Z8R0KLBx1CmpPRqI9lDHm13cG0CRM3xoLzTaI7yH/HBO0RTHA==
   dependencies:
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/utils" "0.29.0-52"
+    "@polkadot/api" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-48.tgz#271086de1b19050a03f157bfe8752b3ea0298ed6"
-  integrity sha512-XstoLiliO0f4T62VgZC5+cCiK7F5crykO7+i5rgj4PmBt5edi3qfccZkYZ8i+kDq6tFxIjSpb3PZMmiRjogT7A==
+"@kiltprotocol/core@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-52.tgz#3587c24fd309947e7cd2cf8004519fce3bba7abb"
+  integrity sha512-UgIjyQwnUf5xfWGTBdi7on6KSgPAo6OSyHOO3pRg8qgbwURhQOdbqNUliHI5DfizNDTOGy3dtQrWLaMMtmKOTg==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/did@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-48.tgz#9c1c8c55a20061f4f0743e39d53eaa475a5cb5c5"
-  integrity sha512-ZtKstuze0A4gc0JTj9+Akp/6gEMvCYSZWPl8mFZW+sTpJ6G71YgJvFwQGsWhEsm3236YyfgLg0SFFJ2u4pwV/w==
+"@kiltprotocol/did@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-52.tgz#32dcfc5b2db2144bd365f14e98542f56f2a22556"
+  integrity sha512-BEyuhj1nlsQFXjxyW81Vqf5yRp0K8QLJ0lWESO73BcFIQu/inJpeh8oIXJpAabYEMyK3ck9Fv/GJOa+UshumNw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
@@ -130,54 +130,53 @@
     "@polkadot/util-crypto" "^10.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-48.tgz#8fc5b5881caa08ce50a52154ecb6d52411bca3bf"
-  integrity sha512-Ras4T04CIbi9qcaXDZHIMOKo4UAU7C9X1WVIVu+YwGS4AURTs8HKUqTizcp3HH6gO1qAlz8puFdkvRIh9wH2RQ==
+"@kiltprotocol/messaging@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-52.tgz#9a56dd4832a04043d576e45909015735b7c4ee82"
+  integrity sha512-ihx2HuqAxQtuVJqNEEarRotvcQRHxnjT/iiBEWDtVIJdwjqSfFFf3eG05F8vdMWi8PjQFpPNkAFslkG0qy/b8w==
   dependencies:
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/util" "^10.0.0"
 
-"@kiltprotocol/sdk-js@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-48.tgz#b0edbd98d973c76ff15005fcda716918fe95db47"
-  integrity sha512-6aM5uj5Ub7D2t+pkVvwDRMxQ+kFUl+IRzhy/IMsk8odus3Zx7ltEcjcwXjEgdPPhyKEehA1B8J/dSHZokODqhA==
+"@kiltprotocol/sdk-js@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-52.tgz#5421dceeabb1766a44ef0e879c890f4d96e7a046"
+  integrity sha512-d6vRGDZqZGTVL9j9Ga/zb9r+gL/KfChYQ3cpVPl4t7ZfelUyGrqD5UnFf90IbC5n2WBtgUB5WOrunJhNaPFa4Q==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/messaging" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/messaging" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
 
-"@kiltprotocol/types@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-48.tgz#39c9d83da472cfcb25a74728920fb9c2af2eb83a"
-  integrity sha512-T99QLEZ26zpi8WZONi8IfVoN8ikJpg55dGDEWWC7lVUjKKhU2dTghK1GeAw/wFAZE6mNwx1HHtD9L7lkJ+Yh6g==
+"@kiltprotocol/types@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-52.tgz#e8fb16ff82273bb3d56ce786a19f49001e671611"
+  integrity sha512-oKjsgiysJova5g+K2C7G3/JKTF6bm5FlBznPuDSfjRyGgzpjbzQQ3KzJ3ySLcqfhIzmATH7QsPhvJ+FVnD+Uiw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
-    tweetnacl "^1.0.3"
+    "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/utils@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-48.tgz#849403b8474fd1db1b5e47b7a79dd604e4a5733b"
-  integrity sha512-SAeI+K8O6q96uBxnkDxnwSbgmDtBxC6Yi1qdBbkDrPfPiQ4cM3EFIIi81iXQQ4Hoqwcm5GvYt6WyLaLGp6Pgcw==
+"@kiltprotocol/utils@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-52.tgz#6fd434cb07af486071d6df8cd3d974c432530674"
+  integrity sha512-l7RIjIhhPTLrwuA2KZtS6iW6NplKlff53XgSyJFcOq73HXp/sOIflAWIyznmNuMnBZVLdS3QMR77uQdZv4Q8lA==
   dependencies:
-    "@kiltprotocol/types" "0.29.0-48"
+    "@kiltprotocol/types" "0.29.0-52"
     "@polkadot/keyring" "^10.0.0"
-    "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
     tweetnacl "^1.0.3"
-    uuid "^8.1.0"
+    uuid "^9.0.0"
 
 "@noble/hashes@1.1.2":
   version "1.1.2"
@@ -2398,10 +2397,10 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-uuid@^8.1.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"

--- a/code_examples/vitejs/package.json
+++ b/code_examples/vitejs/package.json
@@ -9,7 +9,7 @@
     "fix": "yarn lint:fix && yarn style:fix"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.29.0-48",
+    "@kiltprotocol/sdk-js": "0.29.0-52",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/code_examples/vitejs/src/App.tsx
+++ b/code_examples/vitejs/src/App.tsx
@@ -6,7 +6,7 @@ export function App() {
   const [did, setDid] = useState('')
   useEffect(() => {
     const resolveWeb3Name = async () => {
-      await Kilt.init({ address: 'wss://spiritnet.kilt.io' })
+      await Kilt.connect('wss://spiritnet.kilt.io')
       const did = await Kilt.Did.Web3Names.queryDidForWeb3Name('john_doe')
       setDid(did || 'unknown')
     }

--- a/code_examples/vitejs/yarn.lock
+++ b/code_examples/vitejs/yarn.lock
@@ -330,58 +330,58 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kiltprotocol/augment-api@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-48.tgz#6117de30d5af7a2013ad6ae83185a69dcd80d8c5"
-  integrity sha512-hGBrKwJe/0MvWfgl2PtxWoz0O+LWeHmG6NXiPDnjX2o7gdiZJyLj87my6be/QUe1yb1AZYvf7EuOoI7pxHgvRA==
+"@kiltprotocol/augment-api@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-52.tgz#2eaea02e48ed3abf92e39109d1828f3e0b57fb12"
+  integrity sha512-B+omHQIe4zIo4ZCsy39+e1YYzmdOPBWW4268u2qQQ2HiLq7YFaEQ/t0vQKL/g1xIerIg8oNfi2m03zYBumPHGA==
 
-"@kiltprotocol/chain-helpers@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-48.tgz#ee41f21866377de1b0b30b471bc4935b6e3aabc4"
-  integrity sha512-jO6Pfd2pd1Xjamyd5xKiCbGWQ6Inw9rKbYpefAD8nJWItI3GUcFZSj7/PlSAUMNXSczth6GqwGLhLowqLham4w==
+"@kiltprotocol/chain-helpers@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-52.tgz#65d267c219971291eac61d2ccd3b027249909a68"
+  integrity sha512-vXlu6JBzvEUqXsl6bc4+esVLzD2ysMhkYMerCnnWYT6gRt8CUCoUrHKrU5bVqOnPDX9LBDT2o6KuAt7PECkrlA==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/types" "^9.0.0"
 
-"@kiltprotocol/config@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-48.tgz#195071acea6fa3b830513b145300ccb5d2ee2313"
-  integrity sha512-hVsHpGWQpGipOiQGkF0AspXQUv2YzyWOJ7e53wJsRrQf+FHvxRDRhdFHqHsWF/oI2ljIZKHCWkD81a4rRaRseQ==
+"@kiltprotocol/config@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-52.tgz#b6c37df57b1a98334c22a366165284c58751d935"
+  integrity sha512-1azuBiv5h5IAfCpACWNY7lmYrOAGzOK3bIno5Z8R0KLBx1CmpPRqI9lDHm13cG0CRM3xoLzTaI7yH/HBO0RTHA==
   dependencies:
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/utils" "0.29.0-52"
+    "@polkadot/api" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-48.tgz#271086de1b19050a03f157bfe8752b3ea0298ed6"
-  integrity sha512-XstoLiliO0f4T62VgZC5+cCiK7F5crykO7+i5rgj4PmBt5edi3qfccZkYZ8i+kDq6tFxIjSpb3PZMmiRjogT7A==
+"@kiltprotocol/core@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-52.tgz#3587c24fd309947e7cd2cf8004519fce3bba7abb"
+  integrity sha512-UgIjyQwnUf5xfWGTBdi7on6KSgPAo6OSyHOO3pRg8qgbwURhQOdbqNUliHI5DfizNDTOGy3dtQrWLaMMtmKOTg==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/did@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-48.tgz#9c1c8c55a20061f4f0743e39d53eaa475a5cb5c5"
-  integrity sha512-ZtKstuze0A4gc0JTj9+Akp/6gEMvCYSZWPl8mFZW+sTpJ6G71YgJvFwQGsWhEsm3236YyfgLg0SFFJ2u4pwV/w==
+"@kiltprotocol/did@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-52.tgz#32dcfc5b2db2144bd365f14e98542f56f2a22556"
+  integrity sha512-BEyuhj1nlsQFXjxyW81Vqf5yRp0K8QLJ0lWESO73BcFIQu/inJpeh8oIXJpAabYEMyK3ck9Fv/GJOa+UshumNw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
@@ -389,54 +389,53 @@
     "@polkadot/util-crypto" "^10.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-48.tgz#8fc5b5881caa08ce50a52154ecb6d52411bca3bf"
-  integrity sha512-Ras4T04CIbi9qcaXDZHIMOKo4UAU7C9X1WVIVu+YwGS4AURTs8HKUqTizcp3HH6gO1qAlz8puFdkvRIh9wH2RQ==
+"@kiltprotocol/messaging@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-52.tgz#9a56dd4832a04043d576e45909015735b7c4ee82"
+  integrity sha512-ihx2HuqAxQtuVJqNEEarRotvcQRHxnjT/iiBEWDtVIJdwjqSfFFf3eG05F8vdMWi8PjQFpPNkAFslkG0qy/b8w==
   dependencies:
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/util" "^10.0.0"
 
-"@kiltprotocol/sdk-js@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-48.tgz#b0edbd98d973c76ff15005fcda716918fe95db47"
-  integrity sha512-6aM5uj5Ub7D2t+pkVvwDRMxQ+kFUl+IRzhy/IMsk8odus3Zx7ltEcjcwXjEgdPPhyKEehA1B8J/dSHZokODqhA==
+"@kiltprotocol/sdk-js@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-52.tgz#5421dceeabb1766a44ef0e879c890f4d96e7a046"
+  integrity sha512-d6vRGDZqZGTVL9j9Ga/zb9r+gL/KfChYQ3cpVPl4t7ZfelUyGrqD5UnFf90IbC5n2WBtgUB5WOrunJhNaPFa4Q==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/messaging" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/messaging" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
 
-"@kiltprotocol/types@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-48.tgz#39c9d83da472cfcb25a74728920fb9c2af2eb83a"
-  integrity sha512-T99QLEZ26zpi8WZONi8IfVoN8ikJpg55dGDEWWC7lVUjKKhU2dTghK1GeAw/wFAZE6mNwx1HHtD9L7lkJ+Yh6g==
+"@kiltprotocol/types@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-52.tgz#e8fb16ff82273bb3d56ce786a19f49001e671611"
+  integrity sha512-oKjsgiysJova5g+K2C7G3/JKTF6bm5FlBznPuDSfjRyGgzpjbzQQ3KzJ3ySLcqfhIzmATH7QsPhvJ+FVnD+Uiw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
-    tweetnacl "^1.0.3"
+    "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/utils@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-48.tgz#849403b8474fd1db1b5e47b7a79dd604e4a5733b"
-  integrity sha512-SAeI+K8O6q96uBxnkDxnwSbgmDtBxC6Yi1qdBbkDrPfPiQ4cM3EFIIi81iXQQ4Hoqwcm5GvYt6WyLaLGp6Pgcw==
+"@kiltprotocol/utils@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-52.tgz#6fd434cb07af486071d6df8cd3d974c432530674"
+  integrity sha512-l7RIjIhhPTLrwuA2KZtS6iW6NplKlff53XgSyJFcOq73HXp/sOIflAWIyznmNuMnBZVLdS3QMR77uQdZv4Q8lA==
   dependencies:
-    "@kiltprotocol/types" "0.29.0-48"
+    "@kiltprotocol/types" "0.29.0-52"
     "@polkadot/keyring" "^10.0.0"
-    "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
     tweetnacl "^1.0.3"
-    uuid "^8.1.0"
+    uuid "^9.0.0"
 
 "@noble/hashes@1.1.2":
   version "1.1.2"
@@ -2958,10 +2957,10 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-uuid@^8.1.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"

--- a/code_examples/workshop/attester/generateCtype.ts
+++ b/code_examples/workshop/attester/generateCtype.ts
@@ -50,7 +50,7 @@ export async function ensureStoredCtype(
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ; (async () => {
+  ;(async () => {
     envConfig()
     await Kilt.connect(process.env.WSS_ADDRESS as string)
     const keyring = new Keyring({

--- a/code_examples/workshop/attester/generateCtype.ts
+++ b/code_examples/workshop/attester/generateCtype.ts
@@ -50,9 +50,9 @@ export async function ensureStoredCtype(
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ;(async () => {
+  ; (async () => {
     envConfig()
-    await Kilt.init({ address: process.env.WSS_ADDRESS })
+    await Kilt.connect(process.env.WSS_ADDRESS as string)
     const keyring = new Keyring({
       ss58Format: Kilt.Utils.ss58Format
     })

--- a/code_examples/workshop/attester/generateDid.ts
+++ b/code_examples/workshop/attester/generateDid.ts
@@ -62,7 +62,7 @@ export async function getFullDid(
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ; (async () => {
+  ;(async () => {
     envConfig()
     await Kilt.connect(process.env.WSS_ADDRESS as string)
     const keyring = new Keyring({

--- a/code_examples/workshop/attester/generateDid.ts
+++ b/code_examples/workshop/attester/generateDid.ts
@@ -11,7 +11,7 @@ import { getAccount } from './generateAccount'
 export async function createFullDid(
   keyring: Keyring,
   signCallback: Kilt.SignCallback
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   const mnemonic = process.env.ATTESTER_MNEMONIC as string
 
   // Load attester account
@@ -53,7 +53,7 @@ export async function createFullDid(
 
 export async function getFullDid(
   didUri: Kilt.DidUri
-): Promise<Kilt.DidDetails> {
+): Promise<Kilt.DidDocument> {
   // make sure the did is already on chain
   const onChain = await Kilt.Did.query(didUri)
   if (!onChain) throw Error(`failed to find on chain did: ${didUri}`)
@@ -62,9 +62,9 @@ export async function getFullDid(
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ;(async () => {
+  ; (async () => {
     envConfig()
-    await Kilt.init({ address: process.env.WSS_ADDRESS })
+    await Kilt.connect(process.env.WSS_ADDRESS as string)
     const keyring = new Keyring({
       ss58Format: Kilt.Utils.ss58Format
     })

--- a/code_examples/workshop/claimer/createClaim.ts
+++ b/code_examples/workshop/claimer/createClaim.ts
@@ -2,7 +2,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 // create a Claim object from lightDid, ctype and given content
 export function createClaim(
-  lightDid: Kilt.DidDetails,
+  lightDid: Kilt.DidDocument,
   ctype: Kilt.ICType,
   content: Kilt.IClaim['contents']
 ): Kilt.IClaim {

--- a/code_examples/workshop/claimer/createPresentation.ts
+++ b/code_examples/workshop/claimer/createPresentation.ts
@@ -2,7 +2,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function createPresentation(
   credential: Kilt.ICredential,
-  lightDid: Kilt.DidDetails,
+  lightDid: Kilt.DidDocument,
   signCallback: Kilt.SignCallback,
   challenge?: string
 ): Promise<Kilt.ICredential> {

--- a/code_examples/workshop/claimer/generateCredential.ts
+++ b/code_examples/workshop/claimer/generateCredential.ts
@@ -53,7 +53,7 @@ export async function generateCredential(
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ; (async () => {
+  ;(async () => {
     envConfig()
     await Kilt.connect(process.env.WSS_ADDRESS as string)
     const keyring = new Keyring({

--- a/code_examples/workshop/claimer/generateCredential.ts
+++ b/code_examples/workshop/claimer/generateCredential.ts
@@ -11,7 +11,7 @@ import { getCtypeSchema } from '../attester/ctypeSchema'
 
 // create and return a RequestForAttestation from claim
 async function credentialFromClaim(
-  lightDid: Kilt.DidDetails,
+  lightDid: Kilt.DidDocument,
   claim: Kilt.IClaim,
   signCallback: Kilt.SignCallback
 ): Promise<Kilt.ICredential> {
@@ -37,7 +37,7 @@ export async function generateCredential(
   )
 
   // create the DID
-  const lightDid = Kilt.Did.createLightDidDetails({
+  const lightDid = Kilt.Did.createLightDidDocument({
     authentication: [authenticationKey as Kilt.NewLightDidVerificationKey],
     keyAgreement: [encryptionKey]
   })
@@ -53,9 +53,9 @@ export async function generateCredential(
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ;(async () => {
+  ; (async () => {
     envConfig()
-    await Kilt.init({ address: process.env.WSS_ADDRESS })
+    await Kilt.connect(process.env.WSS_ADDRESS as string)
     const keyring = new Keyring({
       ss58Format: Kilt.Utils.ss58Format
     })

--- a/code_examples/workshop/claimer/generateLightDid.ts
+++ b/code_examples/workshop/claimer/generateLightDid.ts
@@ -8,7 +8,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 import { generateKeypairs } from './generateKeypairs'
 
 export async function generateLightDid(keyring: Keyring): Promise<{
-  lightDid: Kilt.DidDetails
+  lightDid: Kilt.DidDocument
   mnemonic: string
 }> {
   // create secret and DID public keys
@@ -19,7 +19,7 @@ export async function generateLightDid(keyring: Keyring): Promise<{
   )
 
   // create the DID
-  const lightDid = Kilt.Did.createLightDidDetails({
+  const lightDid = Kilt.Did.createLightDidDocument({
     authentication: [authenticationKey as Kilt.NewLightDidVerificationKey],
     keyAgreement: [encryptionKey]
   })
@@ -32,7 +32,7 @@ export async function generateLightDid(keyring: Keyring): Promise<{
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ;(async () => {
+  ; (async () => {
     envConfig()
     await cryptoWaitReady()
     const keyring = new Keyring({

--- a/code_examples/workshop/claimer/generateLightDid.ts
+++ b/code_examples/workshop/claimer/generateLightDid.ts
@@ -32,7 +32,7 @@ export async function generateLightDid(keyring: Keyring): Promise<{
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ; (async () => {
+  ;(async () => {
     envConfig()
     await cryptoWaitReady()
     const keyring = new Keyring({

--- a/code_examples/workshop/package.json
+++ b/code_examples/workshop/package.json
@@ -11,7 +11,7 @@
     "test": "ts-node test.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.29.0-48",
+    "@kiltprotocol/sdk-js": "0.29.0-52",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {

--- a/code_examples/workshop/test.ts
+++ b/code_examples/workshop/test.ts
@@ -23,8 +23,8 @@ const SEED_ENV = 'FAUCET_SEED'
 async function testWorkshop() {
   envConfig()
   process.env.WSS_ADDRESS = 'wss://peregrine.kilt.io/parachain-public-ws'
-  await Kilt.init({ address: process.env.WSS_ADDRESS })
-  // Kilt.init calls cryptoWaitReady() internally, but if a different version of polkadot is used, then manual waiting must be called
+  await Kilt.connect(process.env.WSS_ADDRESS)
+  // Kilt.connect calls cryptoWaitReady() internally, but if a different version of polkadot is used, then manual waiting must be called
   // FIXME: remove this once the same version of @polkadot/wasm-crypto is used in @polkadot/api and in the SDK
   await cryptoWaitReady()
 

--- a/code_examples/workshop/verify.ts
+++ b/code_examples/workshop/verify.ts
@@ -47,7 +47,7 @@ export async function verificationFlow() {
     keyring,
     process.env.CLAIMER_MNEMONIC
   )
-  const lightDid = Kilt.Did.createLightDidDetails({
+  const lightDid = Kilt.Did.createLightDidDocument({
     authentication: [authenticationKey as Kilt.NewLightDidVerificationKey],
     keyAgreement: [encryptionKey]
   })
@@ -75,9 +75,9 @@ export async function verificationFlow() {
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ;(async () => {
+  ; (async () => {
     envConfig()
-    await Kilt.init({ address: process.env.WSS_ADDRESS })
+    await Kilt.connect(process.env.WSS_ADDRESS as string)
 
     try {
       await verificationFlow()

--- a/code_examples/workshop/verify.ts
+++ b/code_examples/workshop/verify.ts
@@ -75,7 +75,7 @@ export async function verificationFlow() {
 
 // don't execute if this is imported by another file
 if (require.main === module) {
-  ; (async () => {
+  ;(async () => {
     envConfig()
     await Kilt.connect(process.env.WSS_ADDRESS as string)
 

--- a/code_examples/workshop/yarn.lock
+++ b/code_examples/workshop/yarn.lock
@@ -71,58 +71,58 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kiltprotocol/augment-api@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-48.tgz#6117de30d5af7a2013ad6ae83185a69dcd80d8c5"
-  integrity sha512-hGBrKwJe/0MvWfgl2PtxWoz0O+LWeHmG6NXiPDnjX2o7gdiZJyLj87my6be/QUe1yb1AZYvf7EuOoI7pxHgvRA==
+"@kiltprotocol/augment-api@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-52.tgz#2eaea02e48ed3abf92e39109d1828f3e0b57fb12"
+  integrity sha512-B+omHQIe4zIo4ZCsy39+e1YYzmdOPBWW4268u2qQQ2HiLq7YFaEQ/t0vQKL/g1xIerIg8oNfi2m03zYBumPHGA==
 
-"@kiltprotocol/chain-helpers@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-48.tgz#ee41f21866377de1b0b30b471bc4935b6e3aabc4"
-  integrity sha512-jO6Pfd2pd1Xjamyd5xKiCbGWQ6Inw9rKbYpefAD8nJWItI3GUcFZSj7/PlSAUMNXSczth6GqwGLhLowqLham4w==
+"@kiltprotocol/chain-helpers@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-52.tgz#65d267c219971291eac61d2ccd3b027249909a68"
+  integrity sha512-vXlu6JBzvEUqXsl6bc4+esVLzD2ysMhkYMerCnnWYT6gRt8CUCoUrHKrU5bVqOnPDX9LBDT2o6KuAt7PECkrlA==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/types" "^9.0.0"
 
-"@kiltprotocol/config@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-48.tgz#195071acea6fa3b830513b145300ccb5d2ee2313"
-  integrity sha512-hVsHpGWQpGipOiQGkF0AspXQUv2YzyWOJ7e53wJsRrQf+FHvxRDRhdFHqHsWF/oI2ljIZKHCWkD81a4rRaRseQ==
+"@kiltprotocol/config@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-52.tgz#b6c37df57b1a98334c22a366165284c58751d935"
+  integrity sha512-1azuBiv5h5IAfCpACWNY7lmYrOAGzOK3bIno5Z8R0KLBx1CmpPRqI9lDHm13cG0CRM3xoLzTaI7yH/HBO0RTHA==
   dependencies:
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/utils" "0.29.0-52"
+    "@polkadot/api" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-48.tgz#271086de1b19050a03f157bfe8752b3ea0298ed6"
-  integrity sha512-XstoLiliO0f4T62VgZC5+cCiK7F5crykO7+i5rgj4PmBt5edi3qfccZkYZ8i+kDq6tFxIjSpb3PZMmiRjogT7A==
+"@kiltprotocol/core@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-52.tgz#3587c24fd309947e7cd2cf8004519fce3bba7abb"
+  integrity sha512-UgIjyQwnUf5xfWGTBdi7on6KSgPAo6OSyHOO3pRg8qgbwURhQOdbqNUliHI5DfizNDTOGy3dtQrWLaMMtmKOTg==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/did@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-48.tgz#9c1c8c55a20061f4f0743e39d53eaa475a5cb5c5"
-  integrity sha512-ZtKstuze0A4gc0JTj9+Akp/6gEMvCYSZWPl8mFZW+sTpJ6G71YgJvFwQGsWhEsm3236YyfgLg0SFFJ2u4pwV/w==
+"@kiltprotocol/did@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-52.tgz#32dcfc5b2db2144bd365f14e98542f56f2a22556"
+  integrity sha512-BEyuhj1nlsQFXjxyW81Vqf5yRp0K8QLJ0lWESO73BcFIQu/inJpeh8oIXJpAabYEMyK3ck9Fv/GJOa+UshumNw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
@@ -130,54 +130,53 @@
     "@polkadot/util-crypto" "^10.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-48.tgz#8fc5b5881caa08ce50a52154ecb6d52411bca3bf"
-  integrity sha512-Ras4T04CIbi9qcaXDZHIMOKo4UAU7C9X1WVIVu+YwGS4AURTs8HKUqTizcp3HH6gO1qAlz8puFdkvRIh9wH2RQ==
+"@kiltprotocol/messaging@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-52.tgz#9a56dd4832a04043d576e45909015735b7c4ee82"
+  integrity sha512-ihx2HuqAxQtuVJqNEEarRotvcQRHxnjT/iiBEWDtVIJdwjqSfFFf3eG05F8vdMWi8PjQFpPNkAFslkG0qy/b8w==
   dependencies:
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/util" "^10.0.0"
 
-"@kiltprotocol/sdk-js@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-48.tgz#b0edbd98d973c76ff15005fcda716918fe95db47"
-  integrity sha512-6aM5uj5Ub7D2t+pkVvwDRMxQ+kFUl+IRzhy/IMsk8odus3Zx7ltEcjcwXjEgdPPhyKEehA1B8J/dSHZokODqhA==
+"@kiltprotocol/sdk-js@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-52.tgz#5421dceeabb1766a44ef0e879c890f4d96e7a046"
+  integrity sha512-d6vRGDZqZGTVL9j9Ga/zb9r+gL/KfChYQ3cpVPl4t7ZfelUyGrqD5UnFf90IbC5n2WBtgUB5WOrunJhNaPFa4Q==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/messaging" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/messaging" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
 
-"@kiltprotocol/types@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-48.tgz#39c9d83da472cfcb25a74728920fb9c2af2eb83a"
-  integrity sha512-T99QLEZ26zpi8WZONi8IfVoN8ikJpg55dGDEWWC7lVUjKKhU2dTghK1GeAw/wFAZE6mNwx1HHtD9L7lkJ+Yh6g==
+"@kiltprotocol/types@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-52.tgz#e8fb16ff82273bb3d56ce786a19f49001e671611"
+  integrity sha512-oKjsgiysJova5g+K2C7G3/JKTF6bm5FlBznPuDSfjRyGgzpjbzQQ3KzJ3ySLcqfhIzmATH7QsPhvJ+FVnD+Uiw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
-    tweetnacl "^1.0.3"
+    "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/utils@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-48.tgz#849403b8474fd1db1b5e47b7a79dd604e4a5733b"
-  integrity sha512-SAeI+K8O6q96uBxnkDxnwSbgmDtBxC6Yi1qdBbkDrPfPiQ4cM3EFIIi81iXQQ4Hoqwcm5GvYt6WyLaLGp6Pgcw==
+"@kiltprotocol/utils@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-52.tgz#6fd434cb07af486071d6df8cd3d974c432530674"
+  integrity sha512-l7RIjIhhPTLrwuA2KZtS6iW6NplKlff53XgSyJFcOq73HXp/sOIflAWIyznmNuMnBZVLdS3QMR77uQdZv4Q8lA==
   dependencies:
-    "@kiltprotocol/types" "0.29.0-48"
+    "@kiltprotocol/types" "0.29.0-52"
     "@polkadot/keyring" "^10.0.0"
-    "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
     tweetnacl "^1.0.3"
-    uuid "^8.1.0"
+    uuid "^9.0.0"
 
 "@noble/hashes@1.1.2":
   version "1.1.2"
@@ -2364,10 +2363,10 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-uuid@^8.1.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"

--- a/docs/develop/03_workshop/02_setup.md
+++ b/docs/develop/03_workshop/02_setup.md
@@ -51,7 +51,7 @@ PILT coins don't have any value and can be requested from the [faucet](https://f
 
 Before you call any SDK functionality, you need to initialize the crypto libraries and configure the SDK.
 For this workshop, we'll be using [Peregrine Testnet](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fperegrine.kilt.io%2Fparachain-public-ws%2F#/explorer).
-This is done by calling `await Kilt.init({ address })` where `address` is the address of the full node you want to connect to.
+This is done by calling `await Kilt.connect(address)` where `address` is the address of the full node you want to connect to.
 For this workshop, use `wss://peregrine.kilt.io/parachain-public-ws`.
 Add the address to your `.env` file.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "yarn generate-examples && yarn check-links && yarn package-code && docusaurus build",
+    "build:no-examples": "yarn check-links && yarn package-code && docusaurus build",
     "check-links": "yarn markdown-link-check -c markdown-link-check.config.json -q docs/**/*.md",
     "swizzle": "docusaurus swizzle",
     "deploy": "yarn run package-code && docusaurus deploy",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,7 @@
     "generate": "ts-node src/main.ts"
   },
   "dependencies": {
-    "@kiltprotocol/sdk-js": "0.29.0-48"
+    "@kiltprotocol/sdk-js": "0.29.0-52"
   },
   "devDependencies": {
     "@types/node": "^17.0.21",

--- a/scripts/src/dids.ts
+++ b/scripts/src/dids.ts
@@ -1,6 +1,10 @@
 import type { Keyring } from '@polkadot/api'
 
-import { blake2AsHex, blake2AsU8a, naclBoxPairFromSecret } from '@polkadot/util-crypto'
+import {
+  blake2AsHex,
+  blake2AsU8a,
+  naclBoxPairFromSecret
+} from '@polkadot/util-crypto'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 

--- a/scripts/src/dids.ts
+++ b/scripts/src/dids.ts
@@ -1,31 +1,30 @@
 import type { Keyring } from '@polkadot/api'
 
-import { blake2AsHex, naclBoxPairFromSecret } from '@polkadot/util-crypto'
-import { hexToU8a } from '@polkadot/util'
+import { blake2AsHex, blake2AsU8a, naclBoxPairFromSecret } from '@polkadot/util-crypto'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 
-let attesterDid: TestDidDetails | undefined
-let claimerDid: TestDidDetails | undefined
+let attesterDid: TestDidDocument | undefined
+let claimerDid: TestDidDocument | undefined
 
 // Add the secret encryption key as a property to the elements of the keyAgreement set. Just for testing.
-export type TestDidDetails = Omit<Kilt.DidDetails, 'keyAgreement'> & {
+export type TestDidDocument = Omit<Kilt.DidDocument, 'keyAgreement'> & {
   keyAgreement: Array<Kilt.DidEncryptionKey & { secretKey: Uint8Array }>
 }
 
 export async function generateAttesterDid(
   keyring: Keyring
-): Promise<TestDidDetails> {
-  const authSeed = Kilt.Utils.Crypto.hashStr('attester-auth')
-  const encSeed = Kilt.Utils.Crypto.hashStr('attester-enc')
+): Promise<TestDidDocument> {
+  const authSeed = blake2AsU8a('attester-auth')
+  const encSeed = blake2AsU8a('attester-enc')
   const authKey = keyring.addFromSeed(
-    hexToU8a(authSeed)
+    authSeed
   ) as Kilt.KiltKeyringPair
   const { publicKey: encPk, secretKey: encSk } = naclBoxPairFromSecret(
-    hexToU8a(encSeed)
+    encSeed
   )
 
-  const details: TestDidDetails = {
+  const details: TestDidDocument = {
     authentication: [
       {
         ...authKey,
@@ -50,17 +49,17 @@ export async function generateAttesterDid(
 
 export async function generateClaimerDid(
   keyring: Keyring
-): Promise<TestDidDetails> {
-  const authSeed = Kilt.Utils.Crypto.hashStr('claimer-auth')
-  const encSeed = Kilt.Utils.Crypto.hashStr('claimer-enc')
+): Promise<TestDidDocument> {
+  const authSeed = blake2AsU8a('claimer-auth')
+  const encSeed = blake2AsU8a('claimer-enc')
   const authKey = keyring.addFromSeed(
-    hexToU8a(authSeed)
+    authSeed
   ) as Kilt.KiltKeyringPair
   const { publicKey: encPk, secretKey: encSk } = naclBoxPairFromSecret(
-    hexToU8a(encSeed)
+    encSeed
   )
 
-  const details: TestDidDetails = {
+  const details: TestDidDocument = {
     authentication: [
       {
         ...authKey,
@@ -85,17 +84,17 @@ export async function generateClaimerDid(
 
 const resolve = async (
   didUri: Kilt.DidUri
-): Promise<Kilt.DidResolvedDetails | null> => {
+): Promise<Kilt.DidResolutionResult | null> => {
   const { did: uriWithNoFragment } = Kilt.Did.Utils.parseDidUri(didUri)
   if (uriWithNoFragment === claimerDid?.uri) {
     return {
       metadata: { deactivated: false },
-      details: claimerDid
+      document: claimerDid
     }
   } else if (uriWithNoFragment === attesterDid?.uri) {
     return {
       metadata: { deactivated: false },
-      details: attesterDid
+      document: attesterDid
     }
   } else {
     return null
@@ -115,12 +114,12 @@ export const resolveKey: Kilt.DidResolveKey = async (
     return null
   }
 
-  const { details } = resolved
-  if (!details) {
+  const { document } = resolved
+  if (!document) {
     return null
   }
 
-  const key = Kilt.Did.getKey(details, keyId)
+  const key = Kilt.Did.getKey(document, keyId)
   if (!key) {
     return null
   }

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -84,58 +84,58 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kiltprotocol/augment-api@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-48.tgz#6117de30d5af7a2013ad6ae83185a69dcd80d8c5"
-  integrity sha512-hGBrKwJe/0MvWfgl2PtxWoz0O+LWeHmG6NXiPDnjX2o7gdiZJyLj87my6be/QUe1yb1AZYvf7EuOoI7pxHgvRA==
+"@kiltprotocol/augment-api@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.29.0-52.tgz#2eaea02e48ed3abf92e39109d1828f3e0b57fb12"
+  integrity sha512-B+omHQIe4zIo4ZCsy39+e1YYzmdOPBWW4268u2qQQ2HiLq7YFaEQ/t0vQKL/g1xIerIg8oNfi2m03zYBumPHGA==
 
-"@kiltprotocol/chain-helpers@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-48.tgz#ee41f21866377de1b0b30b471bc4935b6e3aabc4"
-  integrity sha512-jO6Pfd2pd1Xjamyd5xKiCbGWQ6Inw9rKbYpefAD8nJWItI3GUcFZSj7/PlSAUMNXSczth6GqwGLhLowqLham4w==
+"@kiltprotocol/chain-helpers@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/chain-helpers/-/chain-helpers-0.29.0-52.tgz#65d267c219971291eac61d2ccd3b027249909a68"
+  integrity sha512-vXlu6JBzvEUqXsl6bc4+esVLzD2ysMhkYMerCnnWYT6gRt8CUCoUrHKrU5bVqOnPDX9LBDT2o6KuAt7PECkrlA==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/types" "^9.0.0"
 
-"@kiltprotocol/config@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-48.tgz#195071acea6fa3b830513b145300ccb5d2ee2313"
-  integrity sha512-hVsHpGWQpGipOiQGkF0AspXQUv2YzyWOJ7e53wJsRrQf+FHvxRDRhdFHqHsWF/oI2ljIZKHCWkD81a4rRaRseQ==
+"@kiltprotocol/config@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/config/-/config-0.29.0-52.tgz#b6c37df57b1a98334c22a366165284c58751d935"
+  integrity sha512-1azuBiv5h5IAfCpACWNY7lmYrOAGzOK3bIno5Z8R0KLBx1CmpPRqI9lDHm13cG0CRM3xoLzTaI7yH/HBO0RTHA==
   dependencies:
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/utils" "0.29.0-52"
+    "@polkadot/api" "^9.0.0"
     typescript-logging "^0.6.4"
 
-"@kiltprotocol/core@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-48.tgz#271086de1b19050a03f157bfe8752b3ea0298ed6"
-  integrity sha512-XstoLiliO0f4T62VgZC5+cCiK7F5crykO7+i5rgj4PmBt5edi3qfccZkYZ8i+kDq6tFxIjSpb3PZMmiRjogT7A==
+"@kiltprotocol/core@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/core/-/core-0.29.0-52.tgz#3587c24fd309947e7cd2cf8004519fce3bba7abb"
+  integrity sha512-UgIjyQwnUf5xfWGTBdi7on6KSgPAo6OSyHOO3pRg8qgbwURhQOdbqNUliHI5DfizNDTOGy3dtQrWLaMMtmKOTg==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/did@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-48.tgz#9c1c8c55a20061f4f0743e39d53eaa475a5cb5c5"
-  integrity sha512-ZtKstuze0A4gc0JTj9+Akp/6gEMvCYSZWPl8mFZW+sTpJ6G71YgJvFwQGsWhEsm3236YyfgLg0SFFJ2u4pwV/w==
+"@kiltprotocol/did@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/did/-/did-0.29.0-52.tgz#32dcfc5b2db2144bd365f14e98542f56f2a22556"
+  integrity sha512-BEyuhj1nlsQFXjxyW81Vqf5yRp0K8QLJ0lWESO73BcFIQu/inJpeh8oIXJpAabYEMyK3ck9Fv/GJOa+UshumNw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/config" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/config" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
@@ -143,54 +143,53 @@
     "@polkadot/util-crypto" "^10.0.0"
     cbor "^8.0.2"
 
-"@kiltprotocol/messaging@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-48.tgz#8fc5b5881caa08ce50a52154ecb6d52411bca3bf"
-  integrity sha512-Ras4T04CIbi9qcaXDZHIMOKo4UAU7C9X1WVIVu+YwGS4AURTs8HKUqTizcp3HH6gO1qAlz8puFdkvRIh9wH2RQ==
+"@kiltprotocol/messaging@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/messaging/-/messaging-0.29.0-52.tgz#9a56dd4832a04043d576e45909015735b7c4ee82"
+  integrity sha512-ihx2HuqAxQtuVJqNEEarRotvcQRHxnjT/iiBEWDtVIJdwjqSfFFf3eG05F8vdMWi8PjQFpPNkAFslkG0qy/b8w==
   dependencies:
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
     "@polkadot/util" "^10.0.0"
 
-"@kiltprotocol/sdk-js@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-48.tgz#b0edbd98d973c76ff15005fcda716918fe95db47"
-  integrity sha512-6aM5uj5Ub7D2t+pkVvwDRMxQ+kFUl+IRzhy/IMsk8odus3Zx7ltEcjcwXjEgdPPhyKEehA1B8J/dSHZokODqhA==
+"@kiltprotocol/sdk-js@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.29.0-52.tgz#5421dceeabb1766a44ef0e879c890f4d96e7a046"
+  integrity sha512-d6vRGDZqZGTVL9j9Ga/zb9r+gL/KfChYQ3cpVPl4t7ZfelUyGrqD5UnFf90IbC5n2WBtgUB5WOrunJhNaPFa4Q==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
-    "@kiltprotocol/chain-helpers" "0.29.0-48"
-    "@kiltprotocol/core" "0.29.0-48"
-    "@kiltprotocol/did" "0.29.0-48"
-    "@kiltprotocol/messaging" "0.29.0-48"
-    "@kiltprotocol/types" "0.29.0-48"
-    "@kiltprotocol/utils" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
+    "@kiltprotocol/chain-helpers" "0.29.0-52"
+    "@kiltprotocol/core" "0.29.0-52"
+    "@kiltprotocol/did" "0.29.0-52"
+    "@kiltprotocol/messaging" "0.29.0-52"
+    "@kiltprotocol/types" "0.29.0-52"
+    "@kiltprotocol/utils" "0.29.0-52"
 
-"@kiltprotocol/types@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-48.tgz#39c9d83da472cfcb25a74728920fb9c2af2eb83a"
-  integrity sha512-T99QLEZ26zpi8WZONi8IfVoN8ikJpg55dGDEWWC7lVUjKKhU2dTghK1GeAw/wFAZE6mNwx1HHtD9L7lkJ+Yh6g==
+"@kiltprotocol/types@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/types/-/types-0.29.0-52.tgz#e8fb16ff82273bb3d56ce786a19f49001e671611"
+  integrity sha512-oKjsgiysJova5g+K2C7G3/JKTF6bm5FlBznPuDSfjRyGgzpjbzQQ3KzJ3ySLcqfhIzmATH7QsPhvJ+FVnD+Uiw==
   dependencies:
-    "@kiltprotocol/augment-api" "0.29.0-48"
+    "@kiltprotocol/augment-api" "0.29.0-52"
     "@polkadot/api" "^9.0.0"
     "@polkadot/keyring" "^10.0.0"
     "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
-    tweetnacl "^1.0.3"
+    "@polkadot/util-crypto" "^10.0.0"
 
-"@kiltprotocol/utils@0.29.0-48":
-  version "0.29.0-48"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-48.tgz#849403b8474fd1db1b5e47b7a79dd604e4a5733b"
-  integrity sha512-SAeI+K8O6q96uBxnkDxnwSbgmDtBxC6Yi1qdBbkDrPfPiQ4cM3EFIIi81iXQQ4Hoqwcm5GvYt6WyLaLGp6Pgcw==
+"@kiltprotocol/utils@0.29.0-52":
+  version "0.29.0-52"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/utils/-/utils-0.29.0-52.tgz#6fd434cb07af486071d6df8cd3d974c432530674"
+  integrity sha512-l7RIjIhhPTLrwuA2KZtS6iW6NplKlff53XgSyJFcOq73HXp/sOIflAWIyznmNuMnBZVLdS3QMR77uQdZv4Q8lA==
   dependencies:
-    "@kiltprotocol/types" "0.29.0-48"
+    "@kiltprotocol/types" "0.29.0-52"
     "@polkadot/keyring" "^10.0.0"
-    "@polkadot/types" "^9.0.0"
     "@polkadot/util" "^10.0.0"
     "@polkadot/util-crypto" "^10.0.0"
     tweetnacl "^1.0.3"
-    uuid "^8.1.0"
+    uuid "^9.0.0"
 
 "@noble/hashes@1.1.2":
   version "1.1.2"
@@ -426,7 +425,7 @@
     "@polkadot/util-crypto" "^10.1.7"
     rxjs "^7.5.6"
 
-"@polkadot/util-crypto@10.1.1", "@polkadot/util-crypto@^10.0.0":
+"@polkadot/util-crypto@10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-10.1.1.tgz#c6e16e626e55402fdb44c8bb20ce4a9d7c50b9db"
   integrity sha512-R0V++xXbL2pvnCFIuXnKc/TlNhBkyxcno1u8rmjYNuH9S5GOmi2jY/8cNhbrwk6wafBsi+xMPHrEbUnduk82Ag==
@@ -443,7 +442,7 @@
     ed2curve "^0.3.0"
     tweetnacl "^1.0.3"
 
-"@polkadot/util-crypto@10.1.7", "@polkadot/util-crypto@^10.1.7":
+"@polkadot/util-crypto@10.1.7", "@polkadot/util-crypto@^10.0.0", "@polkadot/util-crypto@^10.1.7":
   version "10.1.7"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-10.1.7.tgz#fe5ea006bf23ae19319f3ac9236905a984a65e2f"
   integrity sha512-zGmSU7a0wdWfpDtfc+Q7fUuW+extu9o1Uh4JpkuwwZ/dxmyW5xlfqVsIScM1pdPyjJsyamX8KwsKiVsW4slasg==
@@ -662,12 +661,7 @@
     pako "^2.0.4"
     ws "^8.8.1"
 
-"@substrate/ss58-registry@^1.24.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.25.0.tgz#0fcd8c9c0e53963a88fbed41f2cbd8a1a5c74cde"
-  integrity sha512-LmCH4QJRdHaeLsLTPSgJaXguMoIW+Ig9fA9LRPpeya9HefVAJ7gZuUYinldv+QmX7evNm5CL0rspNUS8l1DvXg==
-
-"@substrate/ss58-registry@^1.28.0":
+"@substrate/ss58-registry@^1.24.0", "@substrate/ss58-registry@^1.28.0":
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.28.0.tgz#39b7fa355d9b97bcb30ef1eedb47b10c3fddcf03"
   integrity sha512-XPSwSq4CThLyg+OnZ5/LHh3SPDQjRdGS3Ux5ClgWhRCQamlU86FCT1LBwQ/i+ximbdBfqKRRzVhm1ql3AJ9FKQ==
@@ -2419,10 +2413,10 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-uuid@^8.1.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Based on top of https://github.com/KILTprotocol/docs/pull/140.

## Warning

There is currently a dependency duplication of `@polkadot` libraries inside the SDK, which means that calling `cryptoWaitReady()` can sometimes be called on a different library version than used elsewhere, resulting in the error message `WASM not ready`. I temporarily commented out the place where this issue happens (in the dynamic JSON generation), and will re-introduce it once an SDK release candidate with the correctly pinned-down polkadot dependencies is released.

Related to https://github.com/KILTprotocol/ticket/issues/2189.