### PR TITLE
fix: encryption key generation process

### DIFF
--- a/code_examples/core_features/did/02_light_did_complete.ts
+++ b/code_examples/core_features/did/02_light_did_complete.ts
@@ -1,6 +1,6 @@
 import type { Keyring } from '@polkadot/api'
 
-import { randomAsU8a } from '@polkadot/util-crypto'
+import { naclBoxPairFromSecret, randomAsU8a } from '@polkadot/util-crypto'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 
@@ -13,7 +13,7 @@ export async function createCompleteLightDid(
   ) as Kilt.NewLightDidVerificationKey
 
   // Generate the encryption key.
-  const { publicKey: encPublicKey } = keyring.addFromSeed(randomAsU8a(32))
+  const { publicKey: encPublicKey } = naclBoxPairFromSecret(randomAsU8a(32))
 
   const service: Kilt.DidServiceEndpoint[] = [
     {

--- a/code_examples/core_features/did/05_full_did_complete.ts
+++ b/code_examples/core_features/did/05_full_did_complete.ts
@@ -1,6 +1,10 @@
 import type { Keyring } from '@polkadot/api'
 
-import { blake2AsU8a, randomAsU8a } from '@polkadot/util-crypto'
+import {
+  blake2AsU8a,
+  naclBoxPairFromSecret,
+  randomAsU8a
+} from '@polkadot/util-crypto'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 
@@ -23,7 +27,7 @@ export async function createCompleteFullDid(
   const authKet = keyring.addFromSeed(
     authenticationSeed
   ) as Kilt.KiltKeyringPair
-  const { publicKey: encPublicKey } = keyring.addFromSeed(encryptionSeed)
+  const { publicKey: encPublicKey } = naclBoxPairFromSecret(randomAsU8a(32))
   const attKey = keyring.addFromSeed(attestationSeed) as Kilt.KiltKeyringPair
   const delKey = keyring.addFromSeed(delegationSeed) as Kilt.KiltKeyringPair
 

--- a/code_examples/workshop/attester/generateKeypairs.ts
+++ b/code_examples/workshop/attester/generateKeypairs.ts
@@ -1,5 +1,9 @@
+import {
+  naclBoxPairFromSecret,
+  randomAsHex,
+  randomAsU8a
+} from '@polkadot/util-crypto'
 import { Keyring } from '@polkadot/api'
-import { randomAsHex } from '@polkadot/util-crypto'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 
@@ -16,7 +20,7 @@ export function generateKeypairs(
   const authKey = keyring.addFromMnemonic(mnemonic) as Kilt.KiltKeyringPair
 
   // encryption keypair
-  const { publicKey: encryptionPk } = keyring.addFromMnemonic(mnemonic)
+  const { publicKey: encryptionPk } = naclBoxPairFromSecret(randomAsU8a(32))
 
   // build the Attester keys object
   return {

--- a/code_examples/workshop/claimer/generateKeypairs.ts
+++ b/code_examples/workshop/claimer/generateKeypairs.ts
@@ -1,6 +1,10 @@
 import type { Keyring } from '@polkadot/api'
 
-import { randomAsHex } from '@polkadot/util-crypto'
+import {
+  naclBoxPairFromSecret,
+  randomAsHex,
+  randomAsU8a
+} from '@polkadot/util-crypto'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 
@@ -17,7 +21,7 @@ export async function generateKeypairs(
   )) as Kilt.KiltKeyringPair
 
   // encryption keypair
-  const { publicKey: encryptionPk } = await keyring.addFromMnemonic(mnemonic)
+  const { publicKey: encryptionPk } = naclBoxPairFromSecret(randomAsU8a(32))
 
   // build the keys object
   return {


### PR DESCRIPTION
In the update process, encryption keys were wrongly generated from the keyring.
This PR fixes that by using the `naclBoxPairFromSecret` function exposed by the `@polkadot/util-crypto` package.