### PR TITLE
feat: update snippet to use the format for published credentials

### DIFF
--- a/code_examples/core_features/getting_started/06_fetch_endpoint_data.ts
+++ b/code_examples/core_features/getting_started/06_fetch_endpoint_data.ts
@@ -15,8 +15,8 @@ export async function main(
     metadata?: any
   }
   const {
-    data: { credential }
-  } = await axios.get<PublishedCredential>(endpoints[1].urls[0])
+    data: [{ credential }]
+  } = await axios.get<PublishedCredential[]>(endpoints[1].urls[0])
 
   return credential
 }

--- a/code_examples/core_features/getting_started/06_fetch_endpoint_data.ts
+++ b/code_examples/core_features/getting_started/06_fetch_endpoint_data.ts
@@ -10,14 +10,13 @@ export async function main(
 ): Promise<Kilt.IRequestForAttestation> {
   // Define the type of a published credential
   type PublishedCredential = {
-    credential: Kilt.IRequestForAttestation,
+    credential: Kilt.IRequestForAttestation
     // Not relevant for this case, but production applications should parse this field as well
     metadata?: any
   }
-  const { data: { credential } } =
-    await axios.get<PublishedCredential>(
-      endpoints[1].urls[0]
-    )
+  const {
+    data: { credential }
+  } = await axios.get<PublishedCredential>(endpoints[1].urls[0])
 
   return credential
 }

--- a/code_examples/core_features/getting_started/06_fetch_endpoint_data.ts
+++ b/code_examples/core_features/getting_started/06_fetch_endpoint_data.ts
@@ -1,14 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from 'axios'
 
 import * as Kilt from '@kiltprotocol/sdk-js'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// TODO: Use exported type when https://github.com/KILTprotocol/sdk-js/pull/631 is merged.
+
 export async function main(
   endpoints: Kilt.DidServiceEndpoint[]
 ): Promise<Kilt.IRequestForAttestation> {
-  const endpointRequestData = await axios
-    .get<Kilt.IRequestForAttestation>(endpoints[0].urls[0])
-    .then((response) => response.data)
+  // Define the type of a published credential
+  type PublishedCredential = {
+    credential: Kilt.IRequestForAttestation,
+    // Not relevant for this case, but production applications should parse this field as well
+    metadata?: any
+  }
+  const { data: { credential } } =
+    await axios.get<PublishedCredential>(
+      endpoints[1].urls[0]
+    )
 
-  return endpointRequestData
+  return credential
 }

--- a/code_examples/core_features/web3names/03_query_name_credentials.ts
+++ b/code_examples/core_features/web3names/03_query_name_credentials.ts
@@ -65,8 +65,8 @@ export async function queryPublishedCredentials(
   )
   console.log(JSON.stringify(didEndpoints, null, 2))
 
-  // For demonstration, only the first endpoint and its first URL are considered.
-  const firstCredentialCollectionEndpointUrl = didEndpoints[0]?.urls[0]
+  // For demonstration, only one endpoint and its first URL are considered.
+  const firstCredentialCollectionEndpointUrl = didEndpoints[1]?.urls[0]
   if (!firstCredentialCollectionEndpointUrl) {
     console.log(
       `The DID has no service endpoints of type "${PUBLISHED_CREDENTIAL_COLLECTION_V1_TYPE}".`

--- a/code_examples/core_features/web3names/03_query_name_credentials.ts
+++ b/code_examples/core_features/web3names/03_query_name_credentials.ts
@@ -9,7 +9,7 @@ const PUBLISHED_CREDENTIAL_COLLECTION_V1_TYPE =
 type CredentialMetadata = {
   label?: string
   blockNumber?: number
-  txHash?: string
+  txHash?: `0x{string}`
 }
 
 type CredentialEntry = {
@@ -65,8 +65,8 @@ export async function queryPublishedCredentials(
   )
   console.log(JSON.stringify(didEndpoints, null, 2))
 
-  // For demonstration, only one endpoint and its first URL are considered.
-  const firstCredentialCollectionEndpointUrl = didEndpoints[1]?.urls[0]
+  // For demonstration, only the first endpoint and its first URL are considered.
+  const firstCredentialCollectionEndpointUrl = didEndpoints[0]?.urls[0]
   if (!firstCredentialCollectionEndpointUrl) {
     console.log(
       `The DID has no service endpoints of type "${PUBLISHED_CREDENTIAL_COLLECTION_V1_TYPE}".`


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2036.

Uses the standard as defined in the spec https://github.com/KILTprotocol/spec-KiltPublishedCredentialCollectionV1.

## NOTE

This PR is against `master`, as the changes must be integrated live already, since the `john_doe` DID already has the new additional endpoint. Changes will then be merged on `develop` again as part of https://github.com/KILTprotocol/docs/pull/146.