### PR TITLE
feat: use new subscription promise settings

### DIFF
--- a/code_examples/core_features/claiming/01_create_ctype.ts
+++ b/code_examples/core_features/claiming/01_create_ctype.ts
@@ -3,9 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function createDriversLicenseCType(
   creator: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<Kilt.ICType> {
   // Create a new CType definition.
   const ctype = Kilt.CType.fromSchema({
@@ -38,10 +36,7 @@ export async function createDriversLicenseCType(
   // using the KILT account specified in the creation operation.
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedCtypeCreationTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 
   return ctype

--- a/code_examples/core_features/claiming/03_create_attestation.ts
+++ b/code_examples/core_features/claiming/03_create_attestation.ts
@@ -4,9 +4,7 @@ export async function createAttestation(
   attester: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
-  credential: Kilt.ICredential,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  credential: Kilt.ICredential
 ): Promise<void> {
   // Create an attestation object and write its root hash on the chain
   // using the provided attester's full DID.
@@ -25,9 +23,6 @@ export async function createAttestation(
   )
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedAttestationTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/claiming/06_revoke_credential.ts
+++ b/code_examples/core_features/claiming/06_revoke_credential.ts
@@ -5,9 +5,7 @@ export async function revokeCredential(
   submitterAccount: Kilt.KiltKeyringPair,
   signCallback: Kilt.SignCallback,
   credential: Kilt.ICredential,
-  shouldRemove = false,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  shouldRemove = false
 ): Promise<void> {
   const tx = shouldRemove
     ? // If the attestation is to be removed, create a `remove` tx,
@@ -25,7 +23,5 @@ export async function revokeCredential(
   )
 
   // Submit the right tx to the KILT blockchain.
-  await Kilt.Blockchain.signAndSubmitTx(authorizedTx, submitterAccount, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(authorizedTx, submitterAccount)
 }

--- a/code_examples/core_features/claiming/07_reclaim_attestation_deposit.ts
+++ b/code_examples/core_features/claiming/07_reclaim_attestation_deposit.ts
@@ -2,9 +2,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function reclaimAttestationDeposit(
   depositPayer: Kilt.KiltKeyringPair,
-  credential: Kilt.ICredential,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  credential: Kilt.ICredential
 ): Promise<void> {
   // Generate the submittable extrinsic to claim the deposit back.
   const depositReclaimTx = await Kilt.Attestation.getReclaimDepositTx(
@@ -12,7 +10,5 @@ export async function reclaimAttestationDeposit(
   )
 
   // Submit the revocation tx to the KILT blockchain.
-  await Kilt.Blockchain.signAndSubmitTx(depositReclaimTx, depositPayer, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(depositReclaimTx, depositPayer)
 }

--- a/code_examples/core_features/claiming/index.ts
+++ b/code_examples/core_features/claiming/index.ts
@@ -15,9 +15,7 @@ import { revokeCredential } from './06_revoke_credential'
 import { verifyPresentation } from './05_verify_presentation'
 
 export async function runAll(
-  submitterAccount: Kilt.KiltKeyringPair,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  submitterAccount: Kilt.KiltKeyringPair
 ): Promise<void> {
   console.log('Running claiming flow...')
   const keyring = new Keyring({ ss58Format: Kilt.Utils.ss58Format })
@@ -40,16 +38,14 @@ export async function runAll(
     keyring,
     submitterAccount,
     undefined,
-    signCallback,
-    resolveOn
+    signCallback
   )
 
   console.log('1 claming) Create CType')
   const ctype = await createDriversLicenseCType(
     attesterFullDid,
     submitterAccount,
-    signCallback,
-    resolveOn
+    signCallback
   )
   console.log('2 claiming) Create credential')
   const credential = requestAttestation(claimerLightDid, ctype)
@@ -58,8 +54,7 @@ export async function runAll(
     attesterFullDid,
     submitterAccount,
     signCallback,
-    credential,
-    resolveOn
+    credential
   )
   console.log('4 claiming) Create selective disclosure presentation')
   const presentation = await createPresentation(
@@ -76,11 +71,10 @@ export async function runAll(
     submitterAccount,
     signCallback,
     credential,
-    false,
-    resolveOn
+    false
   )
   console.log('7 claiming) Reclaim attestation deposit')
-  await reclaimAttestationDeposit(submitterAccount, credential, resolveOn)
+  await reclaimAttestationDeposit(submitterAccount, credential)
 
   console.log('Claiming flow completed!')
 }

--- a/code_examples/core_features/did/03_light_did_migrate.ts
+++ b/code_examples/core_features/did/03_light_did_migrate.ts
@@ -3,9 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function migrateLightDid(
   lightDid: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<Kilt.DidDocument> {
   // Generate the DID migration extrinsic.
   const migrationTx = await Kilt.Did.Chain.getStoreTx(
@@ -15,9 +13,7 @@ export async function migrateLightDid(
   )
 
   // The extrinsic can then be submitted by the authorized account as usual.
-  await Kilt.Blockchain.signAndSubmitTx(migrationTx, submitterAccount, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(migrationTx, submitterAccount)
 
   // The new information is fetched from the blockchain and returned
   const migratedFullDidUri = Kilt.Did.Utils.getFullDidUri(lightDid.uri)

--- a/code_examples/core_features/did/04_full_did_simple.ts
+++ b/code_examples/core_features/did/04_full_did_simple.ts
@@ -8,9 +8,7 @@ export async function createSimpleFullDid(
   keyring: Keyring,
   submitterAccount: Kilt.KiltKeyringPair,
   authenticationSeed: Uint8Array = randomAsU8a(32),
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<Kilt.DidDocument> {
   // Ask the keyring to generate a new keypair to use for authentication with the generated seed.
   const authKey = keyring.addFromSeed(
@@ -28,9 +26,7 @@ export async function createSimpleFullDid(
     signCallback
   )
 
-  await Kilt.Blockchain.signAndSubmitTx(fullDidCreationTx, submitterAccount, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(fullDidCreationTx, submitterAccount)
 
   // The new information is fetched from the blockchain and returned.
   const fullDid = await Kilt.Did.query(

--- a/code_examples/core_features/did/05_full_did_complete.ts
+++ b/code_examples/core_features/did/05_full_did_complete.ts
@@ -12,9 +12,7 @@ export async function createCompleteFullDid(
   keyring: Keyring,
   submitterAccount: Kilt.KiltKeyringPair,
   authenticationSeed: Uint8Array = randomAsU8a(32),
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<Kilt.DidDocument> {
   // Create the encryption key seed by hasing the provided authentication seed.
   const encryptionSeed = blake2AsU8a(authenticationSeed)
@@ -54,9 +52,7 @@ export async function createCompleteFullDid(
     signCallback
   )
 
-  await Kilt.Blockchain.signAndSubmitTx(fullDidCreationTx, submitterAccount, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(fullDidCreationTx, submitterAccount)
 
   // The new information is fetched from the blockchain and returned.
   const fullDid = await Kilt.Did.query(

--- a/code_examples/core_features/did/06_full_did_update.ts
+++ b/code_examples/core_features/did/06_full_did_update.ts
@@ -9,9 +9,7 @@ export async function updateFullDid(
   keyring: Keyring,
   fullDid: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<Kilt.DidDocument> {
   // Ask the keyring to generate a new keypair to use for authentication.
   const newAuthKey = keyring.addFromSeed(
@@ -38,13 +36,7 @@ export async function updateFullDid(
   })
 
   // Submit the DID update tx to the KILT blockchain after signing it with the authorized KILT account.
-  await Kilt.Blockchain.signAndSubmitTx(
-    authorisedBatchedTxs,
-    submitterAccount,
-    {
-      resolveOn
-    }
-  )
+  await Kilt.Blockchain.signAndSubmitTx(authorisedBatchedTxs, submitterAccount)
 
   // Get the updated DID Document
   const updatedDidDetails = await Kilt.Did.query(fullDid.uri)

--- a/code_examples/core_features/did/07_full_did_batch.ts
+++ b/code_examples/core_features/did/07_full_did_batch.ts
@@ -24,9 +24,7 @@ export async function batchCTypeCreationExtrinsics(
   api: ApiPromise,
   submitterAccount: Kilt.KiltKeyringPair,
   fullDid: Kilt.DidDocument,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   // Create two random demo CTypes
   const ctype1 = getRandomCType()
@@ -44,7 +42,5 @@ export async function batchCTypeCreationExtrinsics(
   })
 
   // The authorized account submits the batch to the chain
-  await Kilt.Blockchain.signAndSubmitTx(authorizedBatch, submitterAccount, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(authorizedBatch, submitterAccount)
 }

--- a/code_examples/core_features/did/09_full_did_delete.ts
+++ b/code_examples/core_features/did/09_full_did_delete.ts
@@ -3,9 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function deleteFullDid(
   submitterAccount: Kilt.KiltKeyringPair,
   fullDid: Kilt.DidDocument,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   // Create a DID deletion operation. We specify the number of endpoints currently stored under the DID because
   // of the upper computation limit required by the blockchain runtime.
@@ -28,9 +26,6 @@ export async function deleteFullDid(
 
   await Kilt.Blockchain.signAndSubmitTx(
     didSignedDeletionExtrinsic,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/did/10_full_did_deposit_reclaim.ts
+++ b/code_examples/core_features/did/10_full_did_deposit_reclaim.ts
@@ -2,9 +2,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function reclaimFullDidDeposit(
   depositPayerAccount: Kilt.KiltKeyringPair,
-  didUri: Kilt.DidUri,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  didUri: Kilt.DidUri
 ): Promise<void> {
   // Generate the submittable extrinsic to claim the deposit back.
   // It includes the DID identifier for which the deposit needs to be returned
@@ -18,9 +16,6 @@ export async function reclaimFullDidDeposit(
   // The submission will fail if `depositPayerAccount` is not the owner of the deposit associated with the given DID identifier.
   await Kilt.Blockchain.signAndSubmitTx(
     depositClaimExtrinsic,
-    depositPayerAccount,
-    {
-      resolveOn
-    }
+    depositPayerAccount
   )
 }

--- a/code_examples/core_features/did/index.ts
+++ b/code_examples/core_features/did/index.ts
@@ -17,9 +17,7 @@ import { signCallbackForKeyring } from '../utils'
 
 export async function runAll(
   api: ApiPromise,
-  submitterAccount: Kilt.KiltKeyringPair,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  submitterAccount: Kilt.KiltKeyringPair
 ): Promise<void> {
   console.log('Running DID flow...')
   const keyring = new Keyring({ ss58Format: Kilt.Utils.ss58Format })
@@ -32,24 +30,21 @@ export async function runAll(
   await migrateLightDid(
     simpleLightDid,
     submitterAccount,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('4 did) Create simple full DID')
   const createdSimpleFullDid = await createSimpleFullDid(
     keyring,
     submitterAccount,
     undefined,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('5 did) Create complete full DID')
   const createdCompleteFullDid = await createCompleteFullDid(
     keyring,
     submitterAccount,
     undefined,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('6 did) Update full DID created at step 5')
   const updatedFullDid = await updateFullDid(
@@ -57,8 +52,7 @@ export async function runAll(
     keyring,
     createdCompleteFullDid,
     submitterAccount,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log(
     '7 did) Use the same full DID created at step 5 to sign the batch'
@@ -67,8 +61,7 @@ export async function runAll(
     api,
     submitterAccount,
     updatedFullDid,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log(
     '8 did) Use the same full DID created at step 5 to generate the signature'
@@ -82,14 +75,9 @@ export async function runAll(
   await deleteFullDid(
     submitterAccount,
     createdSimpleFullDid,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('10 did) Delete full DID created at step 5')
-  await reclaimFullDidDeposit(
-    submitterAccount,
-    createdCompleteFullDid.uri,
-    resolveOn
-  )
+  await reclaimFullDidDeposit(submitterAccount, createdCompleteFullDid.uri)
   console.log('DID flow completed!')
 }

--- a/code_examples/core_features/linking/01_did_link.ts
+++ b/code_examples/core_features/linking/01_did_link.ts
@@ -6,9 +6,7 @@ export async function linkAccountToDid(
   did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   linkedAccount: KeyringPair,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   // The account to be linked has to sign a specifically-crafted payload to prove
   // willingness to be linked to the DID.
@@ -33,9 +31,6 @@ export async function linkAccountToDid(
 
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedAccountLinkingTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/linking/02_account_link.ts
+++ b/code_examples/core_features/linking/02_account_link.ts
@@ -3,9 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function linkDidToAccount(
   did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   // Authorizing the extrinsic with the full DID and submitting it with the provided account
   // results in the submitter's account being linked to the DID authorizing the operation.
@@ -20,9 +18,6 @@ export async function linkDidToAccount(
 
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedAccountLinkingTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/linking/05_did_unlink.ts
+++ b/code_examples/core_features/linking/05_did_unlink.ts
@@ -6,9 +6,7 @@ export async function unlinkAccountFromDid(
   did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   linkedAccountAddress: KeyringPair['address'],
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   // The DID owner removes the link between itself and the specified account.
   const accountUnlinkTx =
@@ -24,9 +22,6 @@ export async function unlinkAccountFromDid(
 
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedAccountUnlinkTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/linking/06_account_unlink.ts
+++ b/code_examples/core_features/linking/06_account_unlink.ts
@@ -3,15 +3,11 @@ import type { KeyringPair } from '@polkadot/keyring/types'
 import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function unlinkDidFromAccount(
-  linkOwnerAccount: KeyringPair,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  linkOwnerAccount: KeyringPair
 ): Promise<void> {
   // The tx does not need to be authorized by a DID, but the submitter account removes its own link.
   const accountUnlinkTx =
     await Kilt.Did.AccountLinks.getLinkRemovalByAccountTx()
 
-  await Kilt.Blockchain.signAndSubmitTx(accountUnlinkTx, linkOwnerAccount, {
-    resolveOn
-  })
+  await Kilt.Blockchain.signAndSubmitTx(accountUnlinkTx, linkOwnerAccount)
 }

--- a/code_examples/core_features/linking/07_reclaim_deposit.ts
+++ b/code_examples/core_features/linking/07_reclaim_deposit.ts
@@ -4,9 +4,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function reclaimLinkDeposit(
   depositPayerAccountAccount: KeyringPair,
-  linkedAccountAddress: KeyringPair['address'],
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  linkedAccountAddress: KeyringPair['address']
 ): Promise<void> {
   // The tx does not need to be authorized by a DID, but the deposit payer's account claims the deposit and removes the link.
   const accountUnlinkTx = await Kilt.Did.AccountLinks.getReclaimDepositTx(
@@ -15,9 +13,6 @@ export async function reclaimLinkDeposit(
 
   await Kilt.Blockchain.signAndSubmitTx(
     accountUnlinkTx,
-    depositPayerAccountAccount,
-    {
-      resolveOn
-    }
+    depositPayerAccountAccount
   )
 }

--- a/code_examples/core_features/linking/index.ts
+++ b/code_examples/core_features/linking/index.ts
@@ -24,9 +24,7 @@ import { signCallbackForKeyring } from '../utils'
 export async function runAll(
   api: ApiPromise,
   submitterAccount: Kilt.KiltKeyringPair,
-  linkAccount: KeyringPair,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  linkAccount: KeyringPair
 ): Promise<void> {
   console.log('Running linking flow...')
   const keyring = new Keyring({ ss58Format: Kilt.Utils.ss58Format })
@@ -34,8 +32,7 @@ export async function runAll(
     keyring,
     submitterAccount,
     undefined,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   const randomWeb3Name = randomUUID().substring(0, 32)
   await claimWeb3Name(
@@ -50,15 +47,13 @@ export async function runAll(
     fullDid,
     submitterAccount,
     linkAccount,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('2 linking) Link DID to submitter account')
   await linkDidToAccount(
     fullDid,
     submitterAccount,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('3 linking) Query web3name for link account with SDK')
   let web3Name = await queryAccountWithSdk(linkAccount.address)
@@ -75,17 +70,15 @@ export async function runAll(
     fullDid,
     submitterAccount,
     linkAccount.address,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('6 linking) Unlink submitter account from DID')
-  await unlinkDidFromAccount(submitterAccount, resolveOn)
+  await unlinkDidFromAccount(submitterAccount)
   console.log('7 linking) Re-add submitter account and claim deposit back')
   await linkDidToAccount(
     fullDid,
     submitterAccount,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   await reclaimLinkDeposit(submitterAccount, submitterAccount.address)
   console.log('Linking flow completed!')

--- a/code_examples/core_features/run_core_features.ts
+++ b/code_examples/core_features/run_core_features.ts
@@ -48,9 +48,7 @@ async function endowAccounts(
   )
   const batchTx = api.tx.utility.batchAll(transferBatch)
   try {
-    await Kilt.Blockchain.signAndSubmitTx(batchTx, faucetAccount, {
-      resolveOn
-    })
+    await Kilt.Blockchain.signAndSubmitTx(batchTx, faucetAccount)
   } catch {
     // Try a second time after a small delay and fetching the right nonce.
     const waitingTime = 2_000 // 2 seconds
@@ -63,7 +61,7 @@ async function endowAccounts(
     const resignedBatchTx = await batchTx.signAsync(faucetAccount, {
       nonce: -1
     })
-    await Kilt.Blockchain.submitSignedTx(resignedBatchTx, { resolveOn })
+    await Kilt.Blockchain.submitSignedTx(resignedBatchTx)
   }
 }
 
@@ -83,6 +81,7 @@ async function main(): Promise<void> {
   }
   await gettingStartedFlow()
 
+  Kilt.config({ submitTxResolveOn: resolveOn })
   const api = await Kilt.connect(nodeAddress)
 
   const keyring = new Keyring({
@@ -114,10 +113,10 @@ async function main(): Promise<void> {
 
   // These should not conflict anymore since all accounts are different
   await Promise.all([
-    runAllClaiming(claimingTestAccount, resolveOn),
-    runAllDid(api, didTestAccount, resolveOn),
-    runAllWeb3(web3TestAccount, resolveOn),
-    runAllLinking(api, accountLinkingTestAccount, faucetAccount, resolveOn),
+    runAllClaiming(claimingTestAccount),
+    runAllDid(api, didTestAccount),
+    runAllWeb3(web3TestAccount),
+    runAllLinking(api, accountLinkingTestAccount, faucetAccount),
     runAllDevSetup()
   ])
 }

--- a/code_examples/core_features/web3names/01_claim.ts
+++ b/code_examples/core_features/web3names/01_claim.ts
@@ -4,9 +4,7 @@ export async function claimWeb3Name(
   did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
   name: Kilt.Did.Web3Names.Web3Name,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   const web3NameClaimTx = await Kilt.Did.Web3Names.getClaimTx(name)
   const authorisedWeb3NameClaimTx = await Kilt.Did.authorizeExtrinsic(
@@ -17,9 +15,6 @@ export async function claimWeb3Name(
   )
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedWeb3NameClaimTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/web3names/04_release.ts
+++ b/code_examples/core_features/web3names/04_release.ts
@@ -3,9 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function releaseWeb3Name(
   did: Kilt.DidDocument,
   submitterAccount: Kilt.KiltKeyringPair,
-  signCallback: Kilt.SignCallback,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  signCallback: Kilt.SignCallback
 ): Promise<void> {
   const web3NameReleaseTx = await Kilt.Did.Web3Names.getReleaseByOwnerTx()
   const authorisedWeb3NameReleaseTx = await Kilt.Did.authorizeExtrinsic(
@@ -16,9 +14,6 @@ export async function releaseWeb3Name(
   )
   await Kilt.Blockchain.signAndSubmitTx(
     authorisedWeb3NameReleaseTx,
-    submitterAccount,
-    {
-      resolveOn
-    }
+    submitterAccount
   )
 }

--- a/code_examples/core_features/web3names/05_reclaim_deposit.ts
+++ b/code_examples/core_features/web3names/05_reclaim_deposit.ts
@@ -4,19 +4,11 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function reclaimWeb3NameDeposit(
   depositPayerAccount: KeyringPair,
-  web3Name: Kilt.Did.Web3Names.Web3Name,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  web3Name: Kilt.Did.Web3Names.Web3Name
 ): Promise<void> {
   // Release the web3name by the deposit payer.
   const web3NameReleaseTx = await Kilt.Did.Web3Names.getReclaimDepositTx(
     web3Name
   )
-  await Kilt.Blockchain.signAndSubmitTx(
-    web3NameReleaseTx,
-    depositPayerAccount,
-    {
-      resolveOn
-    }
-  )
+  await Kilt.Blockchain.signAndSubmitTx(web3NameReleaseTx, depositPayerAccount)
 }

--- a/code_examples/core_features/web3names/index.ts
+++ b/code_examples/core_features/web3names/index.ts
@@ -15,9 +15,7 @@ import { verifyNameAndDidEquality } from './02_query_did_name'
 import { signCallbackForKeyring } from '../utils'
 
 export async function runAll(
-  submitterAccount: Kilt.KiltKeyringPair,
-  resolveOn: Kilt.SubscriptionPromise.ResultEvaluator = Kilt.Blockchain
-    .IS_FINALIZED
+  submitterAccount: Kilt.KiltKeyringPair
 ): Promise<void> {
   console.log('Running web3name flow...')
   const keyring = new Keyring({ ss58Format: Kilt.Utils.ss58Format })
@@ -25,8 +23,7 @@ export async function runAll(
     keyring,
     submitterAccount,
     undefined,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   const randomWeb3Name = randomUUID().substring(0, 32)
 
@@ -35,8 +32,7 @@ export async function runAll(
     fullDid,
     submitterAccount,
     randomWeb3Name,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('2 w3n) Verify web3name owner and DID web3name')
   await verifyNameAndDidEquality(randomWeb3Name, fullDid.uri)
@@ -57,17 +53,15 @@ export async function runAll(
   await releaseWeb3Name(
     fullDid,
     submitterAccount,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
   console.log('5 w3n) Re-claim web3name and reclaim deposit')
   await claimWeb3Name(
     fullDid,
     submitterAccount,
     randomWeb3Name,
-    signCallbackForKeyring(keyring),
-    resolveOn
+    signCallbackForKeyring(keyring)
   )
-  await reclaimWeb3NameDeposit(submitterAccount, randomWeb3Name, resolveOn)
+  await reclaimWeb3NameDeposit(submitterAccount, randomWeb3Name)
   console.log('web3name flow completed!')
 }

--- a/code_examples/workshop/test.ts
+++ b/code_examples/workshop/test.ts
@@ -20,6 +20,7 @@ const SEED_ENV = 'FAUCET_SEED'
 async function testWorkshop() {
   envConfig()
   process.env.WSS_ADDRESS = 'wss://peregrine.kilt.io/parachain-public-ws'
+  Kilt.config({ submitTxResolveOn: Kilt.Blockchain.IS_IN_BLOCK })
   await Kilt.connect(process.env.WSS_ADDRESS)
 
   const keyring = new Keyring({


### PR DESCRIPTION
Much needed addition!

Tests for the core features will fail since Spiritnet published credential has changed to the new format, and changes from https://github.com/KILTprotocol/docs/pull/152 must be pulled in first.