### PR TITLE
fix: link checking

### DIFF
--- a/docs/concepts/04_credentials/02_ctypes.md
+++ b/docs/concepts/04_credentials/02_ctypes.md
@@ -19,7 +19,7 @@ This data format is used to define [CType models](https://github.com/KILTprotoco
 The following are all required properties of the schema, with no additional properties allowed:
 
 - **Identifier**: `$id` in the format `kilt:ctype:0x{cTypeHash}`.
-- **KILT specific JSON-Schema**: Accessible at [http://kilt-protocol.org/draft-01/ctype-input](http://kilt-protocol.org/draft-01/ctype-input#).
+- **KILT specific JSON-Schema**: Accessible at [http://kilt-protocol.org/draft-01/ctype#](http://kilt-protocol.org/draft-01/ctype#).
 - **Title**: Defines a user-friendly name for the CType that makes it easier for users to contextualize.
 - **Properties**: Set of fields (e.g., name, birthdate) that the CType can contain, and hence that the Claimer can have attested.
 

--- a/docs/develop/01_sdk/02_cookbook/06_upgrading_to_v0_29/index.md
+++ b/docs/develop/01_sdk/02_cookbook/06_upgrading_to_v0_29/index.md
@@ -8,6 +8,8 @@ Version 0.29.0 is the result of our efforts to make the SDK easier to understand
 As a consequence, quite a few things have changed relative to previous versions.
 These pages serve as a reference point for what to consider when upgrading to make your transition as smooth as possible.
 
+<!-- TODO: remove when release is out -->
+<!-- markdown-link-check-disable-next-line -->
 Find out what has changed and how to upgrade in the [release notes](https://github.com/KILTprotocol/sdk-js/releases/tag/0.29.0).
 
 Also make sure to read up on [how to remain interoperable](./01_backward_compatibility.md) with previous versions of the SDK.

--- a/docs/develop/03_workshop/03_overview.md
+++ b/docs/develop/03_workshop/03_overview.md
@@ -39,7 +39,7 @@ participant B as KILT Blockchain
 The <span className="label-role verifier">Verifier</span> requests a presentation from the  <span className="label-role claimer">Claimer</span> for a specific CType.
 Without a specific CType, the presentation is meaningless.
 Thus, it is important to require this.
-We will [explain CTypes in more detail](attester/ctype) in a later chapter.
+We will [explain CTypes in more detail](./04_attester/03_ctype.md) in a later chapter.
 A presentation is derived from a credential and does not need to contain all attributes.
 A <span className="label-role claimer">Claimer</span> could choose to hide their address from their passport if the <span className="label-role verifier">Verifier</span> is only interested in their age.
 

--- a/docs/develop/03_workshop/04_attester/03_ctype.md
+++ b/docs/develop/03_workshop/04_attester/03_ctype.md
@@ -29,7 +29,7 @@ However, for this workshop we will create our own CType.
 A CType ensures that a credential contains all required attributes, e.g., a driver's license has to contain a name, date of birth, the type of vehicle that can be driven by the claimer.
 The CType is especially important since a Verifier would request credentials for a specific CType (e.g., the traffic police want to see your driver's license and not your gym membership).
 
-If you want to learn more about CTypes take a look at our [in depth CType documentation](/docs/concepts/credentials/ctypes).
+If you want to learn more about CTypes take a look at our [in depth CType documentation](@site/docs/concepts/04_credentials/02_ctypes.md).
 You can also [read through existing CTypes in our CType-index](https://github.com/KILTprotocol/ctype-index).
 :::
 

--- a/docs/develop/03_workshop/04_attester/index.md
+++ b/docs/develop/03_workshop/04_attester/index.md
@@ -8,11 +8,11 @@ import TabItem from '@theme/TabItem';
 
 In this section you will walk though all processes done by the <span className="label-role attester">Attester</span>.
 
-1. You will [create an account](./account) that is used to pay for all transactions and the storage deposits.
-2. The next step is to [create a DID](./did), which is the identity that is used to create attestations.
+1. You will [create an account](./01_account.md) that is used to pay for all transactions and the storage deposits.
+2. The next step is to [create a DID](./02_did.md), which is the identity that is used to create attestations.
    While you can always switch the KILT account and pay deposits and fees with any account you like, your DID stays the same and is the way Claimers will identify you and put trust in you.
-3. Before we can attest claims, [we need a CType](./ctype) which describes and gives context to what we attest.
-4. Once we have a way to pay fees and deposits, have an identity and a CType [we can create attestations](../attestation).
+3. Before we can attest claims, [we need a CType](./03_ctype.md) which describes and gives context to what we attest.
+4. Once we have a way to pay fees and deposits, have an identity and a CType [we can create attestations](../06_attestation.md).
 
 ## Folder Structure
 

--- a/docs/develop/03_workshop/05_claimer/index.md
+++ b/docs/develop/03_workshop/05_claimer/index.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 In this section you will walk though all processes done by the <span className="label-role claimer">Claimer</span>.
 
-1. The first step is to [create a DID](./did), which is the identity that is used to interact with <span className="label-role attester">Attesters</span> and <span className="label-role verifier">Verifiers</span>.
+1. The first step is to [create a DID](./01_did.md), which is the identity that is used to interact with <span className="label-role attester">Attesters</span> and <span className="label-role verifier">Verifiers</span>.
 2. Next, we will create a claim, request a credential and present it to a <span className="label-role verifier">Verifier</span>
 
 ## Folder Structure

--- a/docs/develop/03_workshop/08_done.md
+++ b/docs/develop/03_workshop/08_done.md
@@ -20,6 +20,6 @@ You have also learned how to:
 
 Here are some resources to help you continue your journey in the KILT ecosystem:
 
-- [Download Workshop Code](/workshop.zip) - workshop code
+- [Download Workshop Code](@site/static/workshop.zip) - workshop code
 - [Discord](https://discord.gg/5VZnPdTZMy) - DAO inspired, outcome-focused community
 - [Element](https://matrix.to/#/%23kilt-general:matrix.org) - Technical, Governance, Treasury discussion

--- a/docs/develop/03_workshop/08_done.md
+++ b/docs/develop/03_workshop/08_done.md
@@ -20,6 +20,6 @@ You have also learned how to:
 
 Here are some resources to help you continue your journey in the KILT ecosystem:
 
-- [Download Workshop Code](@site/static/workshop.zip) - workshop code
+- [Download Workshop Code](/workshop.zip) - workshop code
 - [Discord](https://discord.gg/5VZnPdTZMy) - DAO inspired, outcome-focused community
 - [Element](https://matrix.to/#/%23kilt-general:matrix.org) - Technical, Governance, Treasury discussion

--- a/docs/participate/01_staking/05_troubleshooting.md
+++ b/docs/participate/01_staking/05_troubleshooting.md
@@ -54,7 +54,7 @@ If you have stopped receiving rewards, either
    3. They are offline.
 
 In cases 1. or 2i., your stake will automatically be unstaked and prepared for [unlocking](./04_unlock_unstaked.md).
-Otherwise, in cases 2ii. and 2iii., you need to [manually initiate the unlocking period](./03_delegate/05_exit.md/) if you don't want to or cannot delegate to another collator candidate.
+Otherwise, in cases 2ii. and 2iii., you need to [manually initiate the unlocking period](./03_delegate/05_exit.md) if you don't want to or cannot delegate to another collator candidate.
 </TabItem>
 </Tabs>
 

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -8,5 +8,10 @@
   "aliveStatusCodes": [
     200,
     403
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^#.+"
+    }
   ]
 }

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -3,6 +3,10 @@
     {
       "pattern": "^@site/",
       "replacement": "{{BASEURL}}/"
+    },
+    {
+      "pattern": "^/img/",
+      "replacement": "{{BASEURL}}/static/img/"
     }
   ],
   "aliveStatusCodes": [

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -5,8 +5,8 @@
       "replacement": "{{BASEURL}}/"
     },
     {
-      "pattern": "^/",
-      "replacement": "{{BASEURL}}/static/"
+      "pattern": "^/img/",
+      "replacement": "{{BASEURL}}/static/img/"
     }
   ],
   "aliveStatusCodes": [

--- a/markdown-link-check.config.json
+++ b/markdown-link-check.config.json
@@ -5,8 +5,8 @@
       "replacement": "{{BASEURL}}/"
     },
     {
-      "pattern": "^/img/",
-      "replacement": "{{BASEURL}}/static/img/"
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/static/"
     }
   ],
   "aliveStatusCodes": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "yarn check-ts && yarn check-links && yarn generate-examples && yarn package-code && docusaurus build",
+    "build": "yarn check-ts && yarn generate-examples && yarn package-code && yarn check-links && docusaurus build",
     "check-links": "yarn markdown-link-check -c markdown-link-check.config.json -q $(find docs -name '*.md')",
     "check-ts": "yarn check-ts:core_features && yarn check-ts:dapp_examples && yarn check-ts:vitejs && yarn check-ts:workshop",
     "check-ts:core_features": "cd code_examples/core_features && yarn install && yarn check-ts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "yarn check-ts && yarn check-links && yarn generate-examples && yarn package-code && docusaurus build",
-    "check-links": "yarn glob-exec 'docs/**/*.md' 'markdown-link-check -c markdown-link-check.config.json -q {{files.join(\" \")}}'",
+    "check-links": "yarn markdown-link-check -c markdown-link-check.config.json -q $(find docs -name '*.md')",
     "check-ts": "yarn check-ts:core_features && yarn check-ts:dapp_examples && yarn check-ts:vitejs && yarn check-ts:workshop",
     "check-ts:core_features": "cd code_examples/core_features && yarn install && yarn check-ts",
     "check-ts:dapp_examples": "cd code_examples/dapp && yarn install && yarn check-ts",
@@ -49,8 +49,7 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-markdown": "^8.0.3",
-    "glob-exec": "^0.1.1"
+    "react-markdown": "^8.0.3"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "yarn check-ts && yarn check-links && yarn generate-examples && yarn package-code && docusaurus build",
-    "check-links": "yarn markdown-link-check -c markdown-link-check.config.json -q docs/**/*.md",
+    "check-links": "yarn glob-exec 'docs/**/*.md' 'markdown-link-check -c markdown-link-check.config.json -q {{files.join(\" \")}}'",
     "check-ts": "yarn check-ts:core_features && yarn check-ts:dapp_examples && yarn check-ts:vitejs && yarn check-ts:workshop",
     "check-ts:core_features": "cd code_examples/core_features && yarn install && yarn check-ts",
     "check-ts:dapp_examples": "cd code_examples/dapp && yarn install && yarn check-ts",
@@ -49,7 +49,8 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-markdown": "^8.0.3"
+    "react-markdown": "^8.0.3",
+    "glob-exec": "^0.1.1"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5250,14 +5250,6 @@ github-slugger@^1.4.0:
   resolved "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz"
   integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
 
-glob-exec@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/glob-exec/-/glob-exec-0.1.1.tgz#d7bd878e867d6b925ea056baecc56271ba5e6713"
-  integrity sha512-/ZbFcEUsNRPh6PExnQiM1oq80AzREcbHYJvvcqv10as0qiNlVe/Q+gdmsVcaguEclpt2m8EpQNqVpVVLU1UE1w==
-  dependencies:
-    glob "7.1.X"
-    subarg "1.0.X"
-
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -5277,7 +5269,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.1.X, glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
   version "7.1.7"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -6902,11 +6894,6 @@ minimatch@3.0.4, minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimist@^1.1.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
@@ -9003,13 +8990,6 @@ stylis@^4.0.10:
   version "4.0.10"
   resolved "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz"
   integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
-
-subarg@1.0.X:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
-  integrity sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==
-  dependencies:
-    minimist "^1.1.0"
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5250,6 +5250,14 @@ github-slugger@^1.4.0:
   resolved "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz"
   integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
 
+glob-exec@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/glob-exec/-/glob-exec-0.1.1.tgz#d7bd878e867d6b925ea056baecc56271ba5e6713"
+  integrity sha512-/ZbFcEUsNRPh6PExnQiM1oq80AzREcbHYJvvcqv10as0qiNlVe/Q+gdmsVcaguEclpt2m8EpQNqVpVVLU1UE1w==
+  dependencies:
+    glob "7.1.X"
+    subarg "1.0.X"
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -5269,7 +5277,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
+glob@7.1.X, glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
   version "7.1.7"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -6894,6 +6902,11 @@ minimatch@3.0.4, minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
@@ -8990,6 +9003,13 @@ stylis@^4.0.10:
   version "4.0.10"
   resolved "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz"
   integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
+
+subarg@1.0.X:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  integrity sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==
+  dependencies:
+    minimist "^1.1.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2240

Checks all the links in markdown files. The problem resides in glob extension working differently in zsh as compared to bash / sh. While zsh recursively matches all files, sh used by yarn to run package scripts considers `/**/` to indicate exactly one level of nesting. Fixed this using `find`. Also explored a solution using the npm package `glob-exec`.

This PR additionally fixes a few broken links we've overlooked so far.

## How to test:

Break a link!

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
