### PR TITLE
fix verify example and add fileNames to code example

### DIFF
--- a/code_examples/workshop/verify.ts
+++ b/code_examples/workshop/verify.ts
@@ -61,6 +61,7 @@ export async function verificationFlow(
 if (require.main === module) {
   ;(async () => {
     envConfig()
+    await Kilt.connect(process.env.WSS_ADDRESS as string)
 
     try {
       const claimerDidMnemonic = process.env.CLAIMER_DID_MNEMONIC as string

--- a/code_examples/workshop/verify.ts
+++ b/code_examples/workshop/verify.ts
@@ -61,9 +61,9 @@ export async function verificationFlow(
 if (require.main === module) {
   ;(async () => {
     envConfig()
-    await Kilt.connect(process.env.WSS_ADDRESS as string)
 
     try {
+      await Kilt.connect(process.env.WSS_ADDRESS as string)
       const claimerDidMnemonic = process.env.CLAIMER_DID_MNEMONIC as string
       const { authentication } = generateKeypairs(claimerDidMnemonic)
       const claimerDid = generateLightDid(claimerDidMnemonic)

--- a/docs/develop/03_workshop/07_verification.md
+++ b/docs/develop/03_workshop/07_verification.md
@@ -31,7 +31,7 @@ A `presentation` also contains a proof that the <span className="label-role clai
 It's not enough to just send our credential as a <span className="label-role claimer">Claimer</span> as we also need to prove ownership of it.
 This is done by creating a presentation and signing the <span className="label-role verifier">Verifier</span>'s challenge.
 
-<TsJsBlock title="claimer/createPresentation">
+<TsJsBlock fileName="claimer/createPresentation">
   {CreatePresentation}
 </TsJsBlock>
 
@@ -43,7 +43,7 @@ challenge for the <span className="label-role claimer">Claimer</span> to sign; t
 We'll also expose `verifyPresentation` which will do the actual verification.
 Copy the code below, this completes the <span className="label-role verifier">Verifier</span> code!
 
-<TsJsBlock title="verify">
+<TsJsBlock fileName="verify">
   {Verify}
 </TsJsBlock>
 


### PR DESCRIPTION
## fixes not working verify.ts code example
add a missing `Kilt.connect()` and add file names to code examples in verify view.

## How to test:
Before this patch run `yarn ts-node verify.ts` and get the error 
```
BlockchainApiMissingError: The blockchain API is not set. Did you forget to call Kilt.connect(…) or Kilt.init(…)?
```

after this patch it works and was tested

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
