### PR TITLE
chore: update code snippets to include revocation check and trusted attester list

### DIFF
--- a/code_examples/sdk_examples/src/core_features/claiming/04_create_presentation.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/04_create_presentation.ts
@@ -3,8 +3,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function createPresentation(
   credential: Kilt.ICredential,
   signCallback: Kilt.SignCallback,
-  selectedAttributes: string[] | undefined = undefined,
-  challenge: string | undefined = undefined
+  selectedAttributes?: string[],
+  challenge?: string
 ): Promise<Kilt.ICredentialPresentation> {
   // Create a presentation with only the specified fields revealed, if specified.
   return Kilt.Credential.createPresentation({

--- a/code_examples/sdk_examples/src/core_features/claiming/05_verify_presentation.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/05_verify_presentation.ts
@@ -2,8 +2,30 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export async function verifyPresentation(
   presentation: Kilt.ICredentialPresentation,
-  challenge: string | undefined = undefined
+  {
+    challenge,
+    trustedAttesterUris = [],
+  }: {
+    challenge?: string,
+    trustedAttesterUris?: Kilt.DidUri[]
+  } = {}
 ): Promise<void> {
   // Verify the presentation with the provided challenge.
   await Kilt.Credential.verifyPresentation(presentation, { challenge })
+
+  // Verify the credential attestation by checking on the blockchain.
+  const api = Kilt.ConfigService.get('api')
+  const attestationChain = await api.query.attestation.attestations(
+    presentation.rootHash
+  )
+  const attestation = Kilt.Attestation.fromChain(
+    attestationChain,
+    presentation.rootHash
+  )
+  if (attestation.revoked) {
+    throw 'Credential has been revoked and hence it\'s not valid.'
+  }
+  if (!trustedAttesterUris.includes(attestation.owner)) {
+    throw `Credential was issued by ${attestation.owner} which is not in the provided list of trusted attesters: ${trustedAttesterUris}.`
+  }
 }

--- a/code_examples/sdk_examples/src/core_features/claiming/05_verify_presentation.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/05_verify_presentation.ts
@@ -23,7 +23,7 @@ export async function verifyPresentation(
     presentation.rootHash
   )
   if (attestation.revoked) {
-    throw "Credential has been revoked and hence it's not valid."
+    throw new Error("Credential has been revoked and hence it's not valid.")
   }
   if (!trustedAttesterUris.includes(attestation.owner)) {
     throw `Credential was issued by ${attestation.owner} which is not in the provided list of trusted attesters: ${trustedAttesterUris}.`

--- a/code_examples/sdk_examples/src/core_features/claiming/05_verify_presentation.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/05_verify_presentation.ts
@@ -4,9 +4,9 @@ export async function verifyPresentation(
   presentation: Kilt.ICredentialPresentation,
   {
     challenge,
-    trustedAttesterUris = [],
+    trustedAttesterUris = []
   }: {
-    challenge?: string,
+    challenge?: string
     trustedAttesterUris?: Kilt.DidUri[]
   } = {}
 ): Promise<void> {
@@ -23,7 +23,7 @@ export async function verifyPresentation(
     presentation.rootHash
   )
   if (attestation.revoked) {
-    throw 'Credential has been revoked and hence it\'s not valid.'
+    throw "Credential has been revoked and hence it's not valid."
   }
   if (!trustedAttesterUris.includes(attestation.owner)) {
     throw `Credential was issued by ${attestation.owner} which is not in the provided list of trusted attesters: ${trustedAttesterUris}.`

--- a/code_examples/sdk_examples/src/core_features/claiming/index.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/index.ts
@@ -64,7 +64,9 @@ export async function runAll(
     ['name', 'id']
   )
   console.log('5 claiming) Verify selective disclosure presentation')
-  await verifyPresentation(presentation, { trustedAttesterUris: [attesterFullDid.uri] })
+  await verifyPresentation(presentation, {
+    trustedAttesterUris: [attesterFullDid.uri]
+  })
   console.log('6 claiming) Revoke credential')
   await revokeCredential(
     attesterFullDid.uri,
@@ -77,7 +79,9 @@ export async function runAll(
     false
   )
   console.log('7 claiming) Presentation should fail to verify after revocation')
-  await verifyPresentation(presentation, { trustedAttesterUris: [attesterFullDid.uri] })
+  await verifyPresentation(presentation, {
+    trustedAttesterUris: [attesterFullDid.uri]
+  })
   console.log('8 claiming) Reclaim attestation deposit')
   await reclaimAttestationDeposit(submitterAccount, credential)
 

--- a/code_examples/sdk_examples/src/core_features/claiming/index.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/index.ts
@@ -83,7 +83,7 @@ export async function runAll(
     await verifyPresentation(presentation, {
       trustedAttesterUris: [attesterFullDid.uri]
     })
-    throw 'Error: verification should fail after revocation'
+    throw new Error('Error: verification should fail after revocation')
     // eslint-disable-next-line no-empty
   } catch {}
   console.log('8 claiming) Reclaim attestation deposit')

--- a/code_examples/sdk_examples/src/core_features/claiming/index.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/index.ts
@@ -64,7 +64,7 @@ export async function runAll(
     ['name', 'id']
   )
   console.log('5 claiming) Verify selective disclosure presentation')
-  await verifyPresentation(presentation)
+  await verifyPresentation(presentation, { trustedAttesterUris: [attesterFullDid.uri] })
   console.log('6 claiming) Revoke credential')
   await revokeCredential(
     attesterFullDid.uri,
@@ -76,7 +76,9 @@ export async function runAll(
     credential,
     false
   )
-  console.log('7 claiming) Reclaim attestation deposit')
+  console.log('7 claiming) Presentation should fail to verify after revocation')
+  await verifyPresentation(presentation, { trustedAttesterUris: [attesterFullDid.uri] })
+  console.log('8 claiming) Reclaim attestation deposit')
   await reclaimAttestationDeposit(submitterAccount, credential)
 
   console.log('Claiming flow completed!')

--- a/code_examples/sdk_examples/src/core_features/claiming/index.ts
+++ b/code_examples/sdk_examples/src/core_features/claiming/index.ts
@@ -79,9 +79,13 @@ export async function runAll(
     false
   )
   console.log('7 claiming) Presentation should fail to verify after revocation')
-  await verifyPresentation(presentation, {
-    trustedAttesterUris: [attesterFullDid.uri]
-  })
+  try {
+    await verifyPresentation(presentation, {
+      trustedAttesterUris: [attesterFullDid.uri]
+    })
+    throw 'Error: verification should fail after revocation'
+    // eslint-disable-next-line no-empty
+  } catch {}
   console.log('8 claiming) Reclaim attestation deposit')
   await reclaimAttestationDeposit(submitterAccount, credential)
 

--- a/code_examples/sdk_examples/src/core_features/getting_started/06_verify_credential.ts
+++ b/code_examples/sdk_examples/src/core_features/getting_started/06_verify_credential.ts
@@ -14,7 +14,7 @@ export async function main(credential: Kilt.ICredential): Promise<void> {
     )
     // Verify that the credential is not revoked. Exception caught by the catch {} block below.
     if (attestation.revoked) {
-      throw 'The credential has been revoked, hence it is not valid.'
+      throw new Error('The credential has been revoked, hence it is not valid.')
     }
     console.log(
       "John Doe's credential is valid!",

--- a/code_examples/sdk_examples/src/core_features/getting_started/06_verify_credential.ts
+++ b/code_examples/sdk_examples/src/core_features/getting_started/06_verify_credential.ts
@@ -3,6 +3,14 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function main(credential: Kilt.ICredential): Promise<void> {
   try {
     await Kilt.Credential.verifyCredential(credential)
+
+    const api = Kilt.ConfigService.get('api')
+    const attestationInfo = await api.query.attestation.attestations(credential.rootHash)
+    const attestation = Kilt.Attestation.fromChain(attestationInfo, credential.rootHash)
+    // Verify that the credential is not revoked. Exception caught by the catch {} block below.
+    if (attestation.revoked) {
+      throw 'The credential has been revoked, hence it is not valid.'
+    }
     console.log(
       "John Doe's credential is valid!",
       JSON.stringify(credential, null, 2)

--- a/code_examples/sdk_examples/src/core_features/getting_started/06_verify_credential.ts
+++ b/code_examples/sdk_examples/src/core_features/getting_started/06_verify_credential.ts
@@ -5,8 +5,13 @@ export async function main(credential: Kilt.ICredential): Promise<void> {
     await Kilt.Credential.verifyCredential(credential)
 
     const api = Kilt.ConfigService.get('api')
-    const attestationInfo = await api.query.attestation.attestations(credential.rootHash)
-    const attestation = Kilt.Attestation.fromChain(attestationInfo, credential.rootHash)
+    const attestationInfo = await api.query.attestation.attestations(
+      credential.rootHash
+    )
+    const attestation = Kilt.Attestation.fromChain(
+      attestationInfo,
+      credential.rootHash
+    )
     // Verify that the credential is not revoked. Exception caught by the catch {} block below.
     if (attestation.revoked) {
       throw 'The credential has been revoked, hence it is not valid.'

--- a/code_examples/sdk_examples/src/core_features/web3names/03_query_name_credentials.ts
+++ b/code_examples/sdk_examples/src/core_features/web3names/03_query_name_credentials.ts
@@ -59,6 +59,15 @@ export async function queryPublishedCredentials(
     credentialCollection.map(async ({ credential }) => {
       await Kilt.Credential.verifyCredential(credential)
 
+      const attestationInfo = await api.query.attestation.attestations(credential.rootHash)
+      const attestation = Kilt.Attestation.fromChain(attestationInfo, credential.rootHash)
+      // Verify that the credential is not revoked.
+      if (attestation.revoked) {
+        throw new Error(
+          'One of the credentials has been revoked, hence it is not valid.'
+        )
+      }
+
       // Verify that the credential refers to the intended subject.
       if (!Kilt.Did.isSameSubject(credential.claim.owner, uri)) {
         throw new Error(

--- a/code_examples/sdk_examples/src/core_features/web3names/03_query_name_credentials.ts
+++ b/code_examples/sdk_examples/src/core_features/web3names/03_query_name_credentials.ts
@@ -59,8 +59,13 @@ export async function queryPublishedCredentials(
     credentialCollection.map(async ({ credential }) => {
       await Kilt.Credential.verifyCredential(credential)
 
-      const attestationInfo = await api.query.attestation.attestations(credential.rootHash)
-      const attestation = Kilt.Attestation.fromChain(attestationInfo, credential.rootHash)
+      const attestationInfo = await api.query.attestation.attestations(
+        credential.rootHash
+      )
+      const attestation = Kilt.Attestation.fromChain(
+        attestationInfo,
+        credential.rootHash
+      )
       // Verify that the credential is not revoked.
       if (attestation.revoked) {
         throw new Error(

--- a/code_examples/sdk_examples/src/dapp/verifier/verifyCredentialMessage.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/verifyCredentialMessage.ts
@@ -65,12 +65,12 @@ export async function main({ session, verifierKeys }: Param) {
       credential.rootHash
     )
     if (attestation.revoked) {
-      console.log('Credential has been revoked and hence it\'s not valid.')
+      console.log("Credential has been revoked and hence it's not valid.")
       return
     }
     if (isTrustedAttester(attestation.owner)) {
       console.log(
-        'The claim is valid. Claimer\'s email:',
+        "The claim is valid. Claimer's email:",
         credential.claim.contents.Email
       )
     }

--- a/code_examples/sdk_examples/src/dapp/verifier/verifyCredentialMessage.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/verifyCredentialMessage.ts
@@ -52,7 +52,7 @@ export async function main({ session, verifierKeys }: Param) {
     try {
       await Kilt.Credential.verifyPresentation(credential)
     } catch (e) {
-      console.log('credential was invalid:', e)
+      console.log('Credential was invalid:', e)
       return
     }
 
@@ -64,9 +64,13 @@ export async function main({ session, verifierKeys }: Param) {
       attestationChain,
       credential.rootHash
     )
+    if (attestation.revoked) {
+      console.log('Credential has been revoked and hence it\'s not valid.')
+      return
+    }
     if (isTrustedAttester(attestation.owner)) {
       console.log(
-        'The claim is valid. Claimers email:',
+        'The claim is valid. Claimer\'s email:',
         credential.claim.contents.Email
       )
     }

--- a/code_examples/sdk_examples/src/dapp/verifier/verifyCredentialMessage.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/verifyCredentialMessage.ts
@@ -49,12 +49,7 @@ export async function main({ session, verifierKeys }: Param) {
     }
     const credential = decryptedMessage.body.content[0]
 
-    try {
-      await Kilt.Credential.verifyPresentation(credential)
-    } catch (e) {
-      console.log('Credential was invalid:', e)
-      return
-    }
+    await Kilt.Credential.verifyPresentation(credential)
 
     const api = Kilt.ConfigService.get('api')
     const attestationChain = await api.query.attestation.attestations(
@@ -65,8 +60,7 @@ export async function main({ session, verifierKeys }: Param) {
       credential.rootHash
     )
     if (attestation.revoked) {
-      console.log("Credential has been revoked and hence it's not valid.")
-      return
+      throw new Error("Credential has been revoked and hence it's not valid.")
     }
     if (isTrustedAttester(attestation.owner)) {
       console.log(

--- a/code_examples/sdk_examples/src/workshop/index.ts
+++ b/code_examples/sdk_examples/src/workshop/index.ts
@@ -61,9 +61,13 @@ export async function testWorkshop(
       keyType: attestation.type
     })
   )
-  await verificationFlow(credential, async ({ data }) => ({
-    signature: authentication.sign(data),
-    keyType: authentication.type,
-    keyUri: `${lightDid.uri}${lightDid.authentication[0].id}`
-  }), [attesterDid.uri])
+  await verificationFlow(
+    credential,
+    async ({ data }) => ({
+      signature: authentication.sign(data),
+      keyType: authentication.type,
+      keyUri: `${lightDid.uri}${lightDid.authentication[0].id}`
+    }),
+    [attesterDid.uri]
+  )
 }

--- a/code_examples/sdk_examples/src/workshop/index.ts
+++ b/code_examples/sdk_examples/src/workshop/index.ts
@@ -65,5 +65,5 @@ export async function testWorkshop(
     signature: authentication.sign(data),
     keyType: authentication.type,
     keyUri: `${lightDid.uri}${lightDid.authentication[0].id}`
-  }))
+  }), [attesterDid.uri])
 }

--- a/code_examples/sdk_examples/src/workshop/verify.ts
+++ b/code_examples/sdk_examples/src/workshop/verify.ts
@@ -17,7 +17,7 @@ async function verifyPresentation(
   api: ApiPromise,
   presentation: Kilt.ICredentialPresentation,
   challenge: string,
-  trustedAttesterUris: Kilt.DidUri[],
+  trustedAttesterUris: Kilt.DidUri[]
 ): Promise<boolean> {
   try {
     await Kilt.Credential.verifyPresentation(presentation, { challenge })
@@ -39,7 +39,7 @@ async function verifyPresentation(
 export async function verificationFlow(
   credential: Kilt.ICredential,
   signCallback: Kilt.SignCallback,
-  trustedAttesterUris: Kilt.DidUri[] = [],
+  trustedAttesterUris: Kilt.DidUri[] = []
 ) {
   const api = Kilt.ConfigService.get('api')
 
@@ -54,7 +54,12 @@ export async function verificationFlow(
   )
 
   // The verifier checks the presentation.
-  const isValid = await verifyPresentation(api, presentation, challenge, trustedAttesterUris || [])
+  const isValid = await verifyPresentation(
+    api,
+    presentation,
+    challenge,
+    trustedAttesterUris || []
+  )
 
   if (isValid) {
     console.log('Verification successful! You are allowed to enter the club 🎉')
@@ -76,11 +81,15 @@ if (require.main === module) {
       const attesterDid = process.env.ATTESTER_DID_URI as Kilt.DidUri
       // Load credential and claimer DID
       const credential = JSON.parse(process.env.CLAIMER_CREDENTIAL as string)
-      await verificationFlow(credential, async ({ data }) => ({
-        signature: authentication.sign(data),
-        keyType: authentication.type,
-        keyUri: `${claimerDid.uri}${claimerDid.authentication[0].id}`
-      }), [attesterDid])
+      await verificationFlow(
+        credential,
+        async ({ data }) => ({
+          signature: authentication.sign(data),
+          keyType: authentication.type,
+          keyUri: `${claimerDid.uri}${claimerDid.authentication[0].id}`
+        }),
+        [attesterDid]
+      )
     } catch (e) {
       console.log('Error in the verification flow')
       throw e

--- a/code_examples/sdk_examples/src/workshop/verify.ts
+++ b/code_examples/sdk_examples/src/workshop/verify.ts
@@ -58,7 +58,7 @@ export async function verificationFlow(
     api,
     presentation,
     challenge,
-    trustedAttesterUris || []
+    trustedAttesterUris
   )
 
   if (isValid) {


### PR DESCRIPTION
Despite `verifyCredential` and `verifyPresentation` not actually interacting with the chain, we mention everywhere we do that but none of the snippets actually do that. So, I introduced such a check everywhere, and also, where it made sense, introduced a list of trusted attester URIs to check against the credential issuer.