### PR TITLE
fix: sdk-release triggered ci workflow

### DIFF
--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -3,9 +3,6 @@ name: test-docs-examples-2
 on:
   repository_dispatch:
     types: [ sdk-update ]
-  push:
-    branches:
-      - rf-fix-triggered-wf
 
 jobs:
   code_examples:

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -25,10 +25,10 @@ jobs:
           include: "code_examples/**/*"
           exclude: "**/*.lock"
           regex: false
-      - name: Test style conventions
+      - name: Install and dedupe
         working-directory: code_examples/sdk_examples/
         run: |
-          yarn install
+          yarn install && npx --yes yarn-dedupe yarn.lock && yarn install
       - name: Run tests
         timeout-minutes: 60
         working-directory: code_examples/sdk_examples/
@@ -54,19 +54,23 @@ jobs:
           include: "code_examples/**/*"
           exclude: "**/*.lock"
           regex: false
-      - name: Test style conventions
+      - name: Install & dedupe
         working-directory: code_examples/vitejs
         run: |
-          yarn install
+          yarn install && npx --yes yarn-dedupe yarn.lock && yarn install
+      - name: Check types
+        working-directory: code_examples/vitejs
+        run: |
+          yarn check-ts && yarn lint
 
   create_pull_request:
     runs-on: ubuntu-latest
-    needs: [ workshop, core_features ]
+    needs: [ vitejs, code_examples ]
     if: success() && !contains(github.event.client_payload.latestTag, 'rc')
     steps:
       - uses: actions/checkout@v1
       - name: Get current package version
-        working-directory: code_examples/sdk_examples/src/core_features
+        working-directory: code_examples/sdk_examples/
         id: kiltprotocol_sdk
         run: echo "::set-output name=current_tag::$(grep kiltprotocol/sdk-js package.json | awk -F \" '{print $4}')"
       - uses: jacobtomlinson/gha-find-replace@v2
@@ -92,15 +96,15 @@ jobs:
       - name: Regenerate yarn lock for SDK examples
         working-directory: code_examples/sdk_examples
         run: |
-          yarn install
+          yarn install && npx --yes yarn-dedupe yarn.lock && yarn install
       - name: Regenerate yarn lock for vitejs
         working-directory: code_examples/vitejs
         run: |
-          yarn install
+          yarn install && npx --yes yarn-dedupe yarn.lock && yarn install
       - name: Regenerate yarn lock for scripts
         working-directory: scripts
         run: |
-          yarn install
+          yarn install && npx --yes yarn-dedupe yarn.lock && yarn install
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -121,7 +125,7 @@ jobs:
 
   create_issue:
     runs-on: ubuntu-latest
-    needs: [ workshop, core_features ]
+    needs: [ vitejs, code_examples ]
     if: failure()
     steps:
       - name: Checkout

--- a/.github/workflows/sdk-update-test.yml
+++ b/.github/workflows/sdk-update-test.yml
@@ -3,6 +3,9 @@ name: test-docs-examples-2
 on:
   repository_dispatch:
     types: [ sdk-update ]
+  push:
+    branches:
+      - rf-fix-triggered-wf
 
 jobs:
   code_examples:

--- a/code_examples/sdk_examples/package.json
+++ b/code_examples/sdk_examples/package.json
@@ -19,7 +19,7 @@
     "dotenv": "^16.0.0"
   },
   "devDependencies": {
-    "@polkadot/types": "9.4.2",
+    "@polkadot/types": "^9.4.1",
     "@types/node": "^17.0.21",
     "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.36.0",

--- a/docs/develop/01_sdk/02_cookbook/07_upgrading_to_v0_29/index.md
+++ b/docs/develop/01_sdk/02_cookbook/07_upgrading_to_v0_29/index.md
@@ -3,13 +3,13 @@ id: howto-upgrade-v29-index
 title: Upgrading to v0.29
 ---
 
-Version 0.30.0 is the result of our efforts to make the SDK easier to understand and to use.
+Version 0.29.0 is the result of our efforts to make the SDK easier to understand and to use.
 
 As a consequence, quite a few things have changed relative to previous versions.
 These pages serve as a reference point for what to consider when upgrading to make your transition as smooth as possible.
 
 <!-- TODO: remove when release is out -->
 <!-- markdown-link-check-disable-next-line -->
-Find out what has changed and how to upgrade in the [release notes](https://github.com/KILTprotocol/sdk-js/releases/tag/0.30.0).
+Find out what has changed and how to upgrade in the [release notes](https://github.com/KILTprotocol/sdk-js/releases/tag/0.29.0).
 
 Also make sure to read up on [how to remain interoperable](./01_backward_compatibility.md) with previous versions of the SDK.


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/2407

Fixes the release triggered workflow which had invalid job references and was not correctly resolving packages after update.
Also fixed the package version in the instructions for upgrading to v0.29, as the search-replace had changed that to 0.30.0 which does not make a lot of sense.

## How to test:

Good question. Any way we can trigger this?

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
