### PR TITLE
fix: concurrency issues by having four different test accounts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         timeout-minutes: 60
         env:
           NODE_OPTIONS: --unhandled-rejections=strict
-          FAUCET_SEED: ${{ secrets.PEREGRINE_FAUCET_SEED }}
+          BASE_MNEMONIC: ${{ secrets.BASE_MNEMONIC }}
         run: |
           yarn install --frozen-lockfile
           yarn test ${{ matrix.test_case }}

--- a/code_examples/sdk_examples/src/core_features/index.ts
+++ b/code_examples/sdk_examples/src/core_features/index.ts
@@ -87,11 +87,7 @@ export async function testCoreFeatures(
     })(),
     (async () => {
       try {
-        await runAllLinking(
-          wssAddress,
-          accountLinkingTestAccount,
-          account
-        )
+        await runAllLinking(wssAddress, accountLinkingTestAccount, account)
       } catch (e) {
         console.error('Linking flow failed')
         throw e

--- a/code_examples/sdk_examples/src/core_features/index.ts
+++ b/code_examples/sdk_examples/src/core_features/index.ts
@@ -17,7 +17,7 @@ const resolveOn: Kilt.SubscriptionPromise.ResultEvaluator =
   Kilt.Blockchain.IS_IN_BLOCK
 
 export async function testCoreFeatures(
-  faucetAccount: Kilt.KeyringPair,
+  account: Kilt.KeyringPair,
   wssAddress: string
 ): Promise<void> {
   // Connects to (and at the end disconnects from) Spiritnet, so it must be called before we connect to Peregrine for the rest of the tests.
@@ -48,7 +48,7 @@ export async function testCoreFeatures(
   // Endow all the needed accounts in one batch transfer, to avoid tx collisions.
   await endowAccounts(
     api,
-    faucetAccount,
+    account,
     [
       claimingTestAccount.address,
       didTestAccount.address,
@@ -90,7 +90,7 @@ export async function testCoreFeatures(
         await runAllLinking(
           wssAddress,
           accountLinkingTestAccount,
-          faucetAccount
+          account
         )
       } catch (e) {
         console.error('Linking flow failed')

--- a/code_examples/sdk_examples/src/dapp/index.ts
+++ b/code_examples/sdk_examples/src/dapp/index.ts
@@ -9,10 +9,7 @@ import { main as getDomainLinkageCredential } from './dapp/domainLinkageClaim'
 import { getFunds } from '../getFunds'
 import { main as signPresentation } from './dapp/signPresentation'
 
-export async function testDapp(
-  account: Kilt.KeyringPair,
-  wssAddress: string
-) {
+export async function testDapp(account: Kilt.KeyringPair, wssAddress: string) {
   console.log('Running the dapp examples!')
 
   Kilt.ConfigService.set({ submitTxResolveOn: Kilt.Blockchain.IS_IN_BLOCK })

--- a/code_examples/sdk_examples/src/dapp/index.ts
+++ b/code_examples/sdk_examples/src/dapp/index.ts
@@ -10,7 +10,7 @@ import { getFunds } from '../getFunds'
 import { main as signPresentation } from './dapp/signPresentation'
 
 export async function testDapp(
-  faucetAccount: Kilt.KeyringPair,
+  account: Kilt.KeyringPair,
   wssAddress: string
 ) {
   console.log('Running the dapp examples!')
@@ -21,7 +21,7 @@ export async function testDapp(
   // Setup attester account.
   const { account: dappAccount } = await generateAccount()
 
-  await getFunds(api, faucetAccount, dappAccount.address, 4)
+  await getFunds(api, account, dappAccount.address, 4)
 
   // Create attester DID & ensure CType.
   const { fullDid: attesterDid, mnemonic: attesterMnemonic } =

--- a/code_examples/sdk_examples/src/staking/index.ts
+++ b/code_examples/sdk_examples/src/staking/index.ts
@@ -9,7 +9,7 @@ import { getUnclaimedStakingRewards } from './rewards/01_query_staking_rewards'
 // We don't expect these tests to pass yet.
 // We would need a collator seed and a delegator seed to test if we can claim rewards.
 export async function testStaking(
-  faucetAccount: Kilt.KeyringPair,
+  account: Kilt.KeyringPair,
   wssAddress: string
 ) {
   const api = await connect(wssAddress)

--- a/code_examples/sdk_examples/src/test.ts
+++ b/code_examples/sdk_examples/src/test.ts
@@ -68,7 +68,9 @@ const MNEMONIC_ENV = 'BASE_MNEMONIC'
     throw new Error('Account seed is missing')
   }
 
-  const baseAccount = await new Keyring({ type: 'sr25519' }).addFromMnemonic(mnemonic)
+  const baseAccount = await new Keyring({ type: 'sr25519' }).addFromMnemonic(
+    mnemonic
+  )
 
   // If any of these flows fail, just send some more tokens to the account that is failing.
   try {

--- a/code_examples/sdk_examples/src/test.ts
+++ b/code_examples/sdk_examples/src/test.ts
@@ -1,13 +1,15 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
+
+import { Keyring } from '@polkadot/api'
 import { config as envConfig } from 'dotenv'
-import { hexToU8a } from '@polkadot/util'
 import { program } from 'commander'
+
 import { testCoreFeatures } from './core_features'
 import { testDapp } from './dapp'
 import { testStaking } from './staking'
 import { testWorkshop } from './workshop'
 
-const SEED_ENV = 'FAUCET_SEED'
+const MNEMONIC_ENV = 'BASE_MNEMONIC'
 
 ;(async () => {
   const whichToRun = {
@@ -56,31 +58,31 @@ const SEED_ENV = 'FAUCET_SEED'
 
   const wssAddress =
     process.env.WSS_ADDRESS || 'wss://peregrine.kilt.io/parachain-public-ws'
-  const faucetSeed = process.env[SEED_ENV]
+  const mnemonic = process.env[MNEMONIC_ENV]
 
-  if (!faucetSeed) {
+  if (!mnemonic) {
     console.log(
-      `Account seed with sufficient balance is required. Set the secret seed using the ${SEED_ENV} environment variable.`
+      `The base mnemonic to generate the test accounts has not been specified.
+        Set the secret seed using the ${MNEMONIC_ENV} environment variable.`
     )
     throw new Error('Account seed is missing')
   }
-  const faucetAccount = Kilt.Utils.Crypto.makeKeypairFromSeed(
-    hexToU8a(faucetSeed),
-    'sr25519'
-  )
 
+  const baseAccount = await new Keyring({ type: 'sr25519' }).addFromMnemonic(mnemonic)
+
+  // If any of these flows fail, just send some more tokens to the account that is failing.
   try {
     if (whichToRun.workshop) {
-      await testWorkshop(faucetAccount, wssAddress)
+      await testWorkshop(baseAccount.derive('//workshop'), wssAddress)
     }
     if (whichToRun.dapp) {
-      await testDapp(faucetAccount, wssAddress)
+      await testDapp(baseAccount.derive('//dapp'), wssAddress)
     }
     if (whichToRun.core) {
-      await testCoreFeatures(faucetAccount, wssAddress)
+      await testCoreFeatures(baseAccount.derive('//core'), wssAddress)
     }
     if (whichToRun.staking) {
-      await testStaking(faucetAccount, wssAddress)
+      await testStaking(baseAccount.derive('//staking'), wssAddress)
     }
     process.exit(0)
   } catch (e) {

--- a/code_examples/sdk_examples/src/workshop/index.ts
+++ b/code_examples/sdk_examples/src/workshop/index.ts
@@ -14,7 +14,7 @@ import { getFunds } from '../getFunds'
 import { verificationFlow } from './verify'
 
 export async function testWorkshop(
-  faucetAccount: Kilt.KeyringPair,
+  account: Kilt.KeyringPair,
   wssAddress: string
 ) {
   console.log('Running the workshop!')
@@ -35,7 +35,7 @@ export async function testWorkshop(
     name: 'Karl'
   })
 
-  await getFunds(api, faucetAccount, attesterAccount.address, 5)
+  await getFunds(api, account, attesterAccount.address, 5)
 
   // Create attester DID & ensure CType.
   const { fullDid: attesterDid, mnemonic: attesterMnemonic } =

--- a/yarn.lock
+++ b/yarn.lock
@@ -6985,7 +6985,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@2.x.x, punycode@^2.1.0, punycode@^2.1.1:
+punycode@2.x.x, punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -7569,7 +7569,7 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==


### PR DESCRIPTION
Replace the current approach of starting all test flows from the faucet account with a different flow where four sub-accounts are derived from a single seed.
The accounts are already funded on Peregrine, and are derived with the paths `//core`, `//workshop`, `//dapp`, and `//staking` respectively. 

This solves the annoying concurrency issues that we've been running into multiple times now.