### PR TITLE
feat: add search bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,25 @@ module.exports = {
     mermaid: true,
   },
   themes: ['@docusaurus/theme-mermaid'],
+  // Config taken from https://docusaurus.io/docs/search#using-algolia-docsearch
+  // `appId`, `apiKey`, and `indexName` were provided in the email
   themeConfig: {
+    algolia: {
+      // The application ID provided by Algolia
+      appId: 'I7C7DMFMTM',
+      // Public API key: it is safe to commit it
+      apiKey: '7645cdf46221542ea3778361ef714b6a',
+      indexName: 'kilt',
+      // Optional: see doc section below
+      contextualSearch: true,
+      // Optional: Algolia search parameters
+      searchParameters: {},
+      // Optional: path for search page that enabled by default (`false` to disable it)
+      searchPagePath: 'search',
+
+      // Algolia-specific configurations
+      placeholder: 'Search within the KILT documentation!',
+    },
     mermaid: {
       theme: { light: 'default', dark: 'dark' },
     },


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2413.

Docusaurus guide at https://docusaurus.io/docs/2.2.0/search#using-algolia-docsearch.

Not sure there's an easy way to test this before it gets merged, since the index is tied to the official `https://docs.kilt.io` domain name. I would suggest to merge this, wait for the first crawl to happen, and then to fix any issues.