### PR TITLE
refactor: tell people to fetch domain linkage credential ctype

### DIFF
--- a/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
@@ -1,16 +1,29 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
-export const domainLinkageCType: Kilt.ICType = {
-  $id: 'kilt:ctype:0x9d271c790775ee831352291f01c5d04c7979713a5896dcf5e81708184cc5c643',
-  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
-  title: 'Domain Linkage Credential',
-  properties: {
-    id: {
-      type: 'string'
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function main(): Promise<Kilt.ICType> {
+  const { creator, createdAt, ...domainLinkageCType } =
+    await Kilt.CType.fetchFromChain(
+      'kilt:ctype:0x9d271c790775ee831352291f01c5d04c7979713a5896dcf5e81708184cc5c643'
+    )
+
+  console.log(JSON.stringify(domainLinkageCType, null, 2))
+
+  /** Prints the following definition:
+  {
+    "$schema": "http://kilt-protocol.org/draft-01/ctype#",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "origin": {
+            "type": "string"
+        }
     },
-    origin: {
-      type: 'string'
-    }
-  },
-  type: 'object'
+    "title": "Domain Linkage Credential",
+    "type": "object",
+    "$id": "kilt:ctype:0x9d271c790775ee831352291f01c5d04c7979713a5896dcf5e81708184cc5c643"
+  }
+  */
+  return domainLinkageCType
 }

--- a/code_examples/sdk_examples/src/dapp/index.ts
+++ b/code_examples/sdk_examples/src/dapp/index.ts
@@ -1,10 +1,10 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 import { main as attestCredential } from './dapp/attestCredential'
 import { createFullDid } from '../workshop/attester/generateDid'
-import { domainLinkageCType } from './dapp/domainLinkageCtype'
 import { main as formatCredential } from './dapp/formatCredential'
 import { generateAccount } from '../workshop/attester/generateAccount'
 import { generateKeypairs as generateAttesterKeypairs } from '../workshop/attester/generateKeypairs'
+import { main as getDomainLinkageCType } from './dapp/domainLinkageCtype'
 import { main as getDomainLinkageCredential } from './dapp/domainLinkageClaim'
 import { getFunds } from '../getFunds'
 import { main as signPresentation } from './dapp/signPresentation'
@@ -26,6 +26,7 @@ export async function testDapp(account: Kilt.KeyringPair, wssAddress: string) {
   const { assertionMethod: assertionMethodKey } =
     generateAttesterKeypairs(attesterMnemonic)
 
+  const domainLinkageCType = await getDomainLinkageCType()
   const { domainLinkageCredential } = getDomainLinkageCredential({
     domainLinkageCType,
     didUri: attesterDid.uri

--- a/docs/develop/07_dApp/02_well-known-did-config.md
+++ b/docs/develop/07_dApp/02_well-known-did-config.md
@@ -48,11 +48,11 @@ Make sure to create the DID with an `assertionMethodKey` so that you are able to
 ### Making the claim
 
 After you get a DID, you can make a claim about that DID.
-The claim has to be based on the [Domain Linkage CType][CType-Domain-Linkage]:
+The claim has to be based on the [Domain Linkage CType][CType-Domain-Linkage], whose definition you can get from the linked GitHub repository, or fetch from the blockchain using the CType's id:
 
-<TsJsBlock>
+<TsJsSnippet funcEnd="return">
   {DomainLinkageCtype}
-</TsJsBlock>
+</TsJsSnippet>
 
 The credential is built from the CType, claim contents, and your dapp's unique DID:
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2414

> The ‘domainLinkageCType’ is explicitly defined, giving the impression that it is ok to customize it; e.i. make your own cType for the well-known-did-config from each dApp. What's the point of registering credential Types on the chain if everybody uses their own?  I think it would be better to fetch and decode the standard registered ‘domainLinkageCType’ from the chain.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
