### PR TITLE
fix: CType schema to include latest $schema

### DIFF
--- a/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
@@ -4,7 +4,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export async function main(): Promise<Kilt.ICType> {
   const { creator, createdAt, ...domainLinkageCType } =
     await Kilt.CType.fetchFromChain(
-      'kilt:ctype:0x9d271c790775ee831352291f01c5d04c7979713a5896dcf5e81708184cc5c643'
+      'kilt:ctype:0xb08800a574c436831a2b9fce00fd16e9df489b2b3695e88a0895d148eca0311e'
     )
 
   console.log(JSON.stringify(domainLinkageCType, null, 2))
@@ -22,7 +22,7 @@ export async function main(): Promise<Kilt.ICType> {
     },
     "title": "Domain Linkage Credential",
     "type": "object",
-    "$id": "kilt:ctype:0x9d271c790775ee831352291f01c5d04c7979713a5896dcf5e81708184cc5c643"
+    "$id": "kilt:ctype:0xb08800a574c436831a2b9fce00fd16e9df489b2b3695e88a0895d148eca0311e"
   }
   */
   return domainLinkageCType

--- a/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
@@ -12,6 +12,7 @@ export async function main(): Promise<Kilt.ICType> {
   /** Prints the following definition:
   {
     "$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/",
+    "additionalProperties": false,
     "properties": {
         "id": {
             "type": "string"

--- a/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/dapp/domainLinkageCtype.ts
@@ -11,7 +11,7 @@ export async function main(): Promise<Kilt.ICType> {
 
   /** Prints the following definition:
   {
-    "$schema": "http://kilt-protocol.org/draft-01/ctype#",
+    "$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/",
     "properties": {
         "id": {
             "type": "string"

--- a/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
@@ -4,7 +4,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export function main() {
   const emailCType: Kilt.ICType = {
     $id: 'kilt:ctype:0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
-    $schema: 'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/',
+    $schema:
+      'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/',
     title: 'Email',
     properties: {
       Email: {

--- a/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
@@ -12,6 +12,7 @@ export function main() {
         type: 'string'
       }
     },
-    type: 'object'
+    type: 'object',
+    additionalProperties: false
   }
 }

--- a/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
@@ -4,7 +4,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 export function main() {
   const emailCType: Kilt.ICType = {
     $id: 'kilt:ctype:0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
-    $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+    $schema: 'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/',
     title: 'Email',
     properties: {
       Email: {

--- a/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
+++ b/code_examples/sdk_examples/src/dapp/verifier/emailCtype.ts
@@ -3,7 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 
 export function main() {
   const emailCType: Kilt.ICType = {
-    $id: 'kilt:ctype:0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
+    $id: 'kilt:ctype:0xae5bc64e500eb576b7b137288cec5d532094e103be46872f1ad54641e477d9fe',
     $schema:
       'ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/',
     title: 'Email',

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -22,8 +22,8 @@ The following are all required properties of the schema:
 - **Reference to CType metaschema (`$schema`)**: Describes what a valid CType must looks like. The latest metaschema is accessible at [ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/](ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/).
 - **Title**: Defines a user-friendly name for the CType that makes it easier for users to contextualize.
 - **Properties**: Set of fields (e.g., name, birthdate) that the CType can contain, and hence that the Claimer can have attested.
-- **Type**: The CType is an object an must be declared.
-- **Additional properties**: The *additionalProperties* is set to false per default, this restriction ensures that unwanted and malicious attesters cannot add properties to the CType without the user's consent.
+- **Type**: Is always `"object"`,  instructing the JSON schema validator to expect an object (where each property is a claim about the Claimer in the credential).
+- **Additional properties**: In newer CTypes, *additionalProperties* must be present and must be set to `false`, restricting allowable claims in a credential to those listed in `properties`.
 
 :::warning
  Deprecation Warning: Property Swap

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -26,11 +26,15 @@ The following are all required properties of the schema:
 - **Additional properties**: In newer CTypes, *additionalProperties* must be present and must be set to `false`, restricting allowable claims in a credential to those listed in `properties`.
 
 :::warning
- Deprecation Warning: Property Swap
+Deprecation Warning: CType metaschema draft-01
 
-Warning: The following CType Schema property value is deprecated.
-Please update your code accordingly to avoid any issues.
-It will mean you should update existing CTypes.
+CTypes based on the `[http://kilt-protocol.org/draft-01/ctype#](http://kilt-protocol.org/draft-01/ctype%23%60)` metaschema are susceptible to faulty or malicious attester integrations that may introduce unexpected properties to a claim.
+Due to this vulnerability, this version of the metaschema is deprecated and its use is discouraged in the creation of new CTypes.
+For optimal security and functionality, it is recommended to use SDK version `0.33.0` or later for creating CTypes.
+This newer version defaults to using the updated metaschema available at [`ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/`](ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/%60).
+
+This also means you should update existing CTypes.
+
 While existing CTypes will continue to work in the short term, we advise to upgrade to the latest metaschema at your earliest convenience.
 
 Old Property Value:  `"$schema": "http://kilt-protocol.org/draft-01/ctype#"`

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -26,7 +26,7 @@ The following are all required properties of the schema, with no additional prop
 :::warning
  Deprecation Warning: Property Swap
 
-Warning: The following CType Schema property value is deprecated and will be replaced in future versions.
+Warning: The following CType Schema property value is deprecated.
 Please update your code accordingly to avoid any issues.
 It will mean you should update existing CTypes.
 The previous version of the CType will work, however, it is advised to upgrade.

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -28,8 +28,8 @@ The following are all required properties of the schema, with no additional prop
 
 Warning: The following CType Schema property value is deprecated and will be replaced in future versions.
 Please update your code accordingly to avoid any issues.
-It will mean you have to update existing CTypes to include the new value.
-However, they are backwards compatible.
+It will mean you should update existing CTypes.
+The previous version of the CType will work, however, it is advised to upgrade.
 
 Old Property Value:  `"$schema": "http://kilt-protocol.org/draft-01/ctype#"`
 
@@ -48,16 +48,6 @@ const newCType = CType.fromProperties(oldCType.title, oldCType.properties, 'V1')
 Update any dependencies or libraries that rely on the `oldCType` to support the latest version of the `newCType`.
 Test thoroughly to ensure the correct behavior and functionality of the new CTypes in your application.
 If you encounter any issues during the migration process or have questions, refer to the documentation or seek support from the relevant community.
-Timeline:
-The `$schema` has been officially removed in the next major release.
-It is strongly advised to make the necessary changes before that release to avoid any disruptions or unexpected behavior.
-
-Note:
-Ignoring this deprecation warning may result in compatibility issues and limited support in future versions.
-Failure to update your code may lead to unexpected errors or loss of functionality.
-
-We appreciate your cooperation in this migration process and apologize for any inconvenience caused.
-Please don't hesitate to reach out if you require further assistance or clarification.
 :::
 
 ### Properties

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -38,9 +38,15 @@ New Property Value:  `"$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4
 Action Required:
 
 Locate all instances where `$schema` is used in your codebase.
-Replace `$schema` with `$schema` in the relevant sections of your code.
-Update any dependencies or libraries that rely on the `$schema` to support the `$schema`.
-Test thoroughly to ensure the correct behavior and functionality of the `$schema` in your application.
+You will need to re-write the CType by taking the old ctype and entering the following code in the relevant sections.
+Where oldCType is the `CType` before the update to verison `0.33.1`.
+
+``` js
+const newCType = CType.fromProperties(oldCType.title, oldCType.properties, 'V1')
+```
+
+Update any dependencies or libraries that rely on the `oldCType` to support the latest version of the `newCType`.
+Test thoroughly to ensure the correct behavior and functionality of the new CTypes in your application.
 If you encounter any issues during the migration process or have questions, refer to the documentation or seek support from the relevant community.
 Timeline:
 The `$schema` has been officially removed in the next major release.

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -19,9 +19,40 @@ This data format is used to define [CType models](https://github.com/KILTprotoco
 The following are all required properties of the schema, with no additional properties allowed:
 
 - **Identifier**: `$id` in the format `kilt:ctype:0x{cTypeHash}`.
-- **KILT specific JSON-Schema**: Accessible at [http://kilt-protocol.org/draft-01/ctype#](http://kilt-protocol.org/draft-01/ctype#).
+- **KILT specific JSON-Schema**: Accessible at [ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/](ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/).
 - **Title**: Defines a user-friendly name for the CType that makes it easier for users to contextualize.
 - **Properties**: Set of fields (e.g., name, birthdate) that the CType can contain, and hence that the Claimer can have attested.
+
+:::warning
+ Deprecation Warning: Property Swap
+
+Warning: The following CType Schema property value is deprecated and will be replaced in future versions.
+Please update your code accordingly to avoid any issues.
+It will mean you have to update existing CTypes to include the new value.
+However, they are backwards compatible.
+
+Old Property Value:  `"$schema": "http://kilt-protocol.org/draft-01/ctype#"`
+
+New Property Value:  `"$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/"`
+
+Action Required:
+
+Locate all instances where `$schema` is used in your codebase.
+Replace `$schema` with `$schema` in the relevant sections of your code.
+Update any dependencies or libraries that rely on the `$schema` to support the `$schema`.
+Test thoroughly to ensure the correct behavior and functionality of the `$schema` in your application.
+If you encounter any issues during the migration process or have questions, refer to the documentation or seek support from the relevant community.
+Timeline:
+The `$schema` has been officially removed in the next major release.
+It is strongly advised to make the necessary changes before that release to avoid any disruptions or unexpected behavior.
+
+Note:
+Ignoring this deprecation warning may result in compatibility issues and limited support in future versions.
+Failure to update your code may lead to unexpected errors or loss of functionality.
+
+We appreciate your cooperation in this migration process and apologize for any inconvenience caused.
+Please don't hesitate to reach out if you require further assistance or clarification.
+:::
 
 ### Properties
 
@@ -33,7 +64,7 @@ When creating a new CType schema, the following properties are required:
 - The format field is optionally:
   - *Date* format e.g., 2012-04-23T18:25:43.511Z
   - *Time* format e.g., T18:25:43.511Z
-  - *URI* format e.g., https://www.example.com
+  - *URI* format e.g., <https://www.example.com>
 
 <CodeBlock className="language-json" title="CType schema example">
   {ctypeSchema}

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -16,12 +16,14 @@ The schema defines which properties exist and what their type should be, e.g., a
 
 KILT uses [JSON Schema](https://json-schema.org/) (currently draft-07) to validate and annotate data in a strict format.
 This data format is used to define [CType models](https://github.com/KILTprotocol/sdk-js/blob/master/packages/core/src/ctype/CType.schemas.ts).
-The following are all required properties of the schema, with no additional properties allowed:
+The following are all required properties of the schema:
 
 - **Identifier**: `$id` in the format `kilt:ctype:0x{cTypeHash}`.
 - **Reference to CType metaschema (`$schema`)**: Describes what a valid CType must looks like. The latest metaschema is accessible at [ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/](ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/).
 - **Title**: Defines a user-friendly name for the CType that makes it easier for users to contextualize.
 - **Properties**: Set of fields (e.g., name, birthdate) that the CType can contain, and hence that the Claimer can have attested.
+- **Type**: The CType is an object an must be declared.
+- **Additional properties**: The *additionalProperties* is set to false per default, this restriction ensures that unwanted and malicious attesters cannot add properties to the CType without the user's consent.
 
 :::warning
  Deprecation Warning: Property Swap

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -19,7 +19,7 @@ This data format is used to define [CType models](https://github.com/KILTprotoco
 The following are all required properties of the schema, with no additional properties allowed:
 
 - **Identifier**: `$id` in the format `kilt:ctype:0x{cTypeHash}`.
-- **KILT specific JSON-Schema**: Accessible at [ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/](ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/).
+- **Reference to CType metaschema (`$schema`)**: Describes what a valid CType must looks like. The latest metaschema is accessible at [ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/](ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/).
 - **Title**: Defines a user-friendly name for the CType that makes it easier for users to contextualize.
 - **Properties**: Set of fields (e.g., name, birthdate) that the CType can contain, and hence that the Claimer can have attested.
 
@@ -35,19 +35,19 @@ Old Property Value:  `"$schema": "http://kilt-protocol.org/draft-01/ctype#"`
 
 New Property Value:  `"$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/"`
 
-Action Required:
+**Migration instructions:** 
 
-Locate all instances where `$schema` is used in your codebase.
-You will need to re-write the CType by taking the old ctype and entering the following code in the relevant sections.
-Where oldCType is the `CType` before the update to verison `0.33.1`.
+Attesters are recommended to transition to issuing credentials using upgraded versions of CTypes currently in use.
+
+Using sdk version `0.33.0` or later, you can produce a copy of an existing CType `oldCType` as follows:
 
 ``` js
 const newCType = CType.fromProperties(oldCType.title, oldCType.properties, 'V1')
 ```
 
-Update any dependencies or libraries that rely on the `oldCType` to support the latest version of the `newCType`.
-Test thoroughly to ensure the correct behavior and functionality of the new CTypes in your application.
-If you encounter any issues during the migration process or have questions, refer to the documentation or seek support from the relevant community.
+The new CType will have the same title and properties as the existing one, but will be based on the new metaschema, resulting in a different hash and id.
+After [registering the new CType on the Kilt blockchain](../../develop/01_sdk/02_cookbook/04_claiming/01_ctype_creation.md), you can use the new CType as a drop-in replacement in issuing credentials.
+Depending verifiers are recommended to accept both the old and new CType during a transition period.
 :::
 
 ### Properties

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -48,6 +48,9 @@ const newCType = CType.fromProperties(oldCType.title, oldCType.properties, 'V1')
 The new CType will have the same title and properties as the existing one, but will be based on the new metaschema, resulting in a different hash and id.
 After [registering the new CType on the Kilt blockchain](../../develop/01_sdk/02_cookbook/04_claiming/01_ctype_creation.md), you can use the new CType as a drop-in replacement in issuing credentials.
 Depending verifiers are recommended to accept both the old and new CType during a transition period.
+Test thoroughly to ensure the correct behaviour and functionality of the new CTypes in your application.
+
+If you encounter any issues during the migration process or have questions, refer to the documentation or seek support from the relevant community.
 :::
 
 ### Properties

--- a/docs/concepts/05_credentials/02_ctypes.md
+++ b/docs/concepts/05_credentials/02_ctypes.md
@@ -31,7 +31,7 @@ The following are all required properties of the schema:
 Warning: The following CType Schema property value is deprecated.
 Please update your code accordingly to avoid any issues.
 It will mean you should update existing CTypes.
-The previous version of the CType will work, however, it is advised to upgrade.
+While existing CTypes will continue to work in the short term, we advise to upgrade to the latest metaschema at your earliest convenience.
 
 Old Property Value:  `"$schema": "http://kilt-protocol.org/draft-01/ctype#"`
 

--- a/docs/develop/03_workshop/04_attester/03_ctype.md
+++ b/docs/develop/03_workshop/04_attester/03_ctype.md
@@ -47,9 +47,11 @@ Let's have a look at these attributes.
 | Key          | Value                                                                                                                                                               |
 | -------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `$id`        | The KILT id of this CType. It is the most important property as it represents the **digital footprint** of the CType.                                               |
-| `$schema`    | A reference to the meta-schema describing what a CType may look like. This is the same for all CTypes.                                                              |
+| `$schema`    | A reference to the meta-schema describing what a CType may look like. There are two versions.                                                              |
 | `title`      | The title of the CType.                                                                                                                                             |
 | `properties` | The properties that a claim conforming to this CType may have.                                                                                                      |
+| `type` | Type is an object for all CTypes.                                                                                                  |
+| `additionalProperties` | The default is set to false. This restricts unwanted properties in a claim.                                                                                                      |
 
 A CType is stored on the KILT blockchain.
 

--- a/scripts/out/ctype-schema.json
+++ b/scripts/out/ctype-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://kilt-protocol.org/draft-01/ctype#",
+  "$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/",
   "title": "Drivers License by did:kilt:4t9FPVbcN42UMxt3Z2Y4Wx38qPL8bLduAB11gLZSwn5hVEfH",
   "properties": {
     "name": {

--- a/scripts/out/ctype-schema.json
+++ b/scripts/out/ctype-schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/",
   "title": "Drivers License by did:kilt:4t9FPVbcN42UMxt3Z2Y4Wx38qPL8bLduAB11gLZSwn5hVEfH",
+  "additionalProperties": false,
   "properties": {
     "name": {
       "type": "string"

--- a/scripts/out/ctype.json
+++ b/scripts/out/ctype.json
@@ -1,6 +1,6 @@
 {
   "$id": "kilt:ctype:0xc22f85da01c18c1b48acf9556ac7167247ce253cc10373ea77f50fc91521d478",
-  "$schema": "http://kilt-protocol.org/draft-01/ctype#",
+  "$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/",
   "properties": {
     "age": {
       "type": "integer"

--- a/scripts/out/ctype.json
+++ b/scripts/out/ctype.json
@@ -1,6 +1,7 @@
 {
-  "$id": "kilt:ctype:0xc22f85da01c18c1b48acf9556ac7167247ce253cc10373ea77f50fc91521d478",
+  "$id": "kilt:ctype:0x4f1d68ac46daf4613181b33b16faaf10cf94879dc2246d7485dc2ccbb843641d",
   "$schema": "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/",
+  "additionalProperties": false,
   "properties": {
     "age": {
       "type": "integer"


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/2789

Fixing the docs concepts and including the new CTypes that require the `$schema: "ipfs://bafybeiah66wbkhqbqn7idkostj2iqyan2tstc4tpqt65udlhimd7hcxjyq/"`

## How to test:

yarn test with env

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
