### PR TITLE
fix: more broken snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KILT Protocol Documentation Website
 
-The KILT Documentation website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+The KILT Documentation website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
 Hosted at https://docs.kilt.io
 

--- a/docs/develop/01_sdk/01_quickstart.md
+++ b/docs/develop/01_sdk/01_quickstart.md
@@ -126,7 +126,7 @@ You should add all other code before this function call:
 <SnippetBlock
 className="language-ts"
 >
-{Disconnect} 
+{Disconnect}
 </SnippetBlock>
 
 By adding `await Kilt.disconnect()`, you ensure that the connection to the blockchain node is properly closed when the script finishes executing, which helps maintain the integrity of your application and is a good practice to follow.
@@ -200,7 +200,7 @@ You do this by selecting one of the endpoints and querying the URL to see if it 
 
 Add the following code after the code you added in the previous step but before `await Kilt.disconnect()`:
 
-<TsJsSnippet funcName="Promise<Kilt.ICredential>" funcEnd="return">
+<TsJsSnippet funcEnd="return">
   {FetchEndpointData}
 </TsJsSnippet>
 

--- a/docs/develop/07_dApp/04_verifier.md
+++ b/docs/develop/07_dApp/04_verifier.md
@@ -3,8 +3,6 @@ id: dapp-verifier
 title: Verifying a Credential
 ---
 
-import CodeBlock from '@theme/CodeBlock';
-import SnippetBlock from '@site/src/components/SnippetBlock';
 import TsJsSnippet from '@site/src/components/TsJsSnippet';
 import TsJsBlock from '@site/src/components/TsJsBlock';
 
@@ -47,9 +45,9 @@ The presentation must include this challenge and since it's random, the presenta
 This ensures that it's not possible to record a presentation and just send this, pretending to be the owner of the DID.
 The challenge can be generated using the polkadot crypto utilities:
 
-<CodeBlock language="js">
+<TsJsBlock>
   {GenerateChallenge}
-</CodeBlock>
+</TsJsBlock>
 
 With the challenge the server can construct the `request-credential` message.
 The request is sent to the light DID (`claimerSessionDid`) that is used to encrypt the messages (see [Session](03_session.md) for more information).

--- a/docs/develop/07_dApp/04_verifier.md
+++ b/docs/develop/07_dApp/04_verifier.md
@@ -3,6 +3,9 @@ id: dapp-verifier
 title: Verifying a Credential
 ---
 
+import CodeBlock from '@theme/CodeBlock';
+import SnippetBlock from '@site/src/components/SnippetBlock';
+import TsJsSnippet from '@site/src/components/TsJsSnippet';
 import TsJsBlock from '@site/src/components/TsJsBlock';
 
 import EmailCtype from '!!raw-loader!@site/code_examples/sdk_examples/src/dapp/verifier/01_email_ctype.ts';
@@ -34,7 +37,9 @@ In this guide the website requests an email address that is owned by the DID.
 For that it uses the Email CType.
 You can search through existing CTypes in the [CType Index](https://github.com/KILTprotocol/ctype-index).
 
+<TsJsSnippet funcEnd="console">
   {EmailCtype}
+</TsJsSnippet>
 
 After settled on a CType, the server can build the request for the visitor.
 Since we want to ensure that the presentation of the credential is fresh, the server first has to create a random challenge.
@@ -42,14 +47,16 @@ The presentation must include this challenge and since it's random, the presenta
 This ensures that it's not possible to record a presentation and just send this, pretending to be the owner of the DID.
 The challenge can be generated using the polkadot crypto utilities:
 
-<TsJsBlock>
+<CodeBlock language="js">
   {GenerateChallenge}
-</TsJsBlock>
+</CodeBlock>
 
 With the challenge the server can construct the `request-credential` message.
 The request is sent to the light DID (`claimerSessionDid`) that is used to encrypt the messages (see [Session](03_session.md) for more information).
 
+<TsJsBlock>
   {CreateRequestCredentialMessage}
+</TsJsBlock>
 
 :::note Privacy
 
@@ -61,7 +68,9 @@ We don't use the full DID of the claimer to establish the encrypted communicatio
 After the server has built the message object, it must encrypt the message for the claimer.
 Once the message is encrypted the server can pass on the message to the extension.
 
+<TsJsBlock>
   {EncryptRequestCredentialMessage}
+</TsJsBlock>
 
 ## Verify the Presentation
 
@@ -70,6 +79,9 @@ After sending the `request-credential` message to the extension, the verifier li
 After the response from the extension is received, forwarded to the server and decrypted, the verifier must check that it has the expected CType and that it contains a valid credential.
 Since everyone can run an attestation service, you need to make sure that you also verify that the attester is trusted.
 
+<!-- TODO: crazy hacky, not even sure we want to use a snippet here; but the example had so much dummy code in it -->
+<TsJsSnippet funcName="})">
   {DecryptCredentialMessage}
+</TsJsSnippet>
 
 That's it! Your verifier has successfully requested and verified a credential.


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3112

Fixed indented code block that are no longer rendered correctly in Docusaurus 3 by making them TsJsBlocks/Snippets.
Wasn't sure why they were not already, and whether we want to show the whole code or just the function contents.
Also fixed one use of the TsJsSnippet that was broken for the js part.

The snippet component is so brittle is practically unusable though.

## How to test:

Look at the pages.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
