### PR TITLE
chore: remove references to scripts/init.sh

### DIFF
--- a/docs/develop/02_chain/04_fullnode.md
+++ b/docs/develop/02_chain/04_fullnode.md
@@ -73,8 +73,6 @@ After cloning the repository, you can build the executable by running the `cargo
 git clone https://github.com/KILTprotocol/kilt-node.git
 # Check out master branch
 git checkout master
-# Set up the build environment by installing the Rust compiler.
-./scripts/init.sh
 # Build the executable from source enabling all the optimizations with --release.
 cargo build --release -p kilt-parachain
 ```

--- a/docs/participate/01_staking/01_become_a_collator/03_setup_node.md
+++ b/docs/participate/01_staking/01_become_a_collator/03_setup_node.md
@@ -104,8 +104,6 @@ After cloning the repository, you can build the executable by running the `cargo
 git clone https://github.com/KILTprotocol/kilt-node.git
 # Check out master branch
 git checkout master
-# Set up the build environment by installing the Rust compiler.
-./scripts/init.sh
 # Build the executable from source enabling all the optimizations with --release.
 cargo build --release -p kilt-parachain
 ```


### PR DESCRIPTION
Removed references to scripts/init.sh, which has since been removed with this PR [KILTprotocol/kilt-node/pull/550](https://github.com/KILTprotocol/kilt-node/pull/550)
