### PR TITLE
Explain derivation paths in documentation

### DIFF
--- a/docs/concepts/07_derivation_paths.md
+++ b/docs/concepts/07_derivation_paths.md
@@ -1,0 +1,4 @@
+---
+id: derivation_paths
+title: Derivation Paths
+---

--- a/docs/concepts/07_derivation_paths.md
+++ b/docs/concepts/07_derivation_paths.md
@@ -1,4 +1,0 @@
----
-id: derivation_paths
-title: Derivation Paths
----

--- a/docs/develop/01_sdk/02_cookbook/01_dids/00_generate_keys.md
+++ b/docs/develop/01_sdk/02_cookbook/01_dids/00_generate_keys.md
@@ -38,7 +38,7 @@ A hard derivation path does not allow someone to do either of these.
 Even if you know a derived private key, it's not possible to figure out the private key of the root address, and it's impossible to prove that the first account is linked with the second.
 
 A `//` (double slash) indicates a hard derivation path.
-For example, `deal rice sunny now boss cluster team use wreck electric wing deliver//0` is a soft derivation path.
+For example, `deal rice sunny now boss cluster team use wreck electric wing deliver//0` is a hard derivation path.
 
 ## Creating new accounts from a seed
 

--- a/docs/develop/01_sdk/02_cookbook/01_dids/00_generate_keys.md
+++ b/docs/develop/01_sdk/02_cookbook/01_dids/00_generate_keys.md
@@ -7,15 +7,45 @@ import TsJsBlock from '@site/src/components/TsJsBlock';
 
 import GenerateKeys from '!!raw-loader!@site/code_examples/sdk_examples/src/core_features/did/00_generate_did_keys.ts';
 
-Creating a Decentralized Identifier (DID) in the KILT network involves generating keying material for authentication and encryption.
-In this guide, we'll demonstrate how to create a set of key pairs suitable for generating a KILT DID.
+Creating a Decentralized Identifier (DID) on the KILT network involves generating keying material for authentication and encryption.
+This guide shows how to create a set of key pairs suitable for generating a KILT DID.
 
-Before we proceed, it's important to note that this example assumes the usage of the `@kiltprotocol/sdk-js` library along with the `@polkadot/util-crypto` library for cryptographic operations.
-Additionally, we want to emphasize the significance of securely storing keys and the mnemonic seed phrase.
+Before proceeding, it's important to note that this example assumes the usage of the `@kiltprotocol/sdk-js` library along with the `@polkadot/util-crypto` library for cryptographic operations.
+
+Additionally, it's important to securely store keys and the mnemonic seed phrase.
 For production use, ensure that private keys are encrypted and stored safely, while also creating a backup of the mnemonic seed phrase.
 
-In the example provided, we derive different types of keys from a single account using derivation paths.
-This approach allows us to generate various key pairs for authentication, key agreement, assertion methods, and capability delegation from one mnemonic seed phrase.
+## Derivation paths
+
+The code example below derives different types of keys from a single account using derivation paths.
+
+A derivation path is a way to derive a new key from a parent key and is a sequence of indices separated by a delimiter.
+The most common delimiter is `/` (forward slash).
+
+KILT uses the same derivation paths as the underlying Polkadot libraries, using soft and hard key derivation.
+
+## Soft derivation
+
+A soft derivation allows someone to potentially figure out the initial account's private key if they know the derived account's private key.
+It is also possible to determine that different accounts generated from the same seed are linked to that seed.
+
+A `/` (single slash) indicates a soft derivation path.
+For example, `deal rice sunny now boss cluster team use wreck electric wing deliver/0` is a soft derivation path.
+
+## Hard derivation
+
+A hard derivation path does not allow someone to do either of these.
+Even if you know a derived private key, it's not possible to figure out the private key of the root address, and it's impossible to prove that the first account is linked with the second.
+
+A `//` (double slash) indicates a hard derivation path.
+For example, `deal rice sunny now boss cluster team use wreck electric wing deliver//0` is a soft derivation path.
+
+## Creating new accounts from a seed
+
+This approach allows you to generate various key pairs for authentication, key agreement, assertion methods, and capability delegation from one mnemonic seed phrase.
+
+To create another account using the same seed, change the number at the end of the string. For example, `/1`, `/2`, and `/3` create different derived accounts.
+
 Using derivation paths simplifies key management, ensuring that a single mnemonic seed serves as the basis for multiple keys associated with a DID.
 This method improves efficiency while maintaining security.
 However, it's essential to handle and store private keys securely to prevent unauthorized access and ensure the overall integrity and privacy of the decentralized identity system.

--- a/docs/develop/03_workshop/04_attester/02_did.md
+++ b/docs/develop/03_workshop/04_attester/02_did.md
@@ -13,7 +13,6 @@ import GenerateDid from '!!raw-loader!@site/code_examples/sdk_examples/src/works
 
 The next step is to generate a KILT decentralized identifier (DID) using the account you created for the <span className="label-role attester">Attester</span> in [the previous step](./01_account.md).
 
-
 A DID may represent any entity, such as a person, an organization, or a machine.
 
 A DID is a string uniquely identifying each KILT user.
@@ -61,7 +60,6 @@ As an <span className="label-role attester">Attester</span> needs to interact wi
 
 ### Generate key pairs
 
-<!-- TODO: Based on feedback, but does this make code samples wrong? -->
 An <span className="label-role attester">Attester</span> needs an authentication and attestation key at minimum.
 Since three of the key types sign transactions, you can use the same key for them using the default KILT keyring to generate them, which is the same keyring used to generate accounts.
 
@@ -70,8 +68,6 @@ Add the following code to the `attester/generateKeypairs` file.
 <TsJsBlock fileName="attester/generateKeypairs">
   {GenerateKeypairs}
 </TsJsBlock>
-
-<!-- TODO: Is this enough? -->
 
 Throughout the code are `account.derive` methods that use key derivation syntax. You can read more about this syntax in [the Substrate documentation](https://docs.substrate.io/reference/command-line-tools/subkey/#working-with-derived-keys).
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2944

Adds documentation on derivation paths.

Could it potentially be in a more accessible location, as it's buried somewhat in the cookbook?