### PR TITLE
chore: replace develop with master links

### DIFF
--- a/docs/develop/02_chain/04_fullnode.md
+++ b/docs/develop/02_chain/04_fullnode.md
@@ -41,7 +41,7 @@ This can either be `peregrine` or `spiritnet`.
 
 Hence, to start a full node for the Spiritnet network, the parameter would be `--chain=spiritnet`.
 Unfortunately, there is no hardcoded chain spec for the Peregrine network, so the full path of the chainspec file must be provided `--chain=/node/dev-specs/kilt-parachain/peregrine-kilt.json`.
-Please refer to the [KILT node repository](https://github.com/KILTprotocol/kilt-node/blob/develop/chainspecs/peregrine/peregrine-paseo.json) or the [Docker image](https://hub.docker.com/r/kiltprotocol/kilt-node/tags) for more information.
+Please refer to the [KILT node repository](https://github.com/KILTprotocol/kilt-node/blob/master/dev-specs/kilt-parachain/peregrine-kilt.json) or the [Docker image](https://hub.docker.com/r/kiltprotocol/kilt-node/tags) for more information.
 
 ### Specify the Blockchain Storage Path
 

--- a/docs/participate/01_staking/01_become_a_collator/03_setup_node.md
+++ b/docs/participate/01_staking/01_become_a_collator/03_setup_node.md
@@ -74,7 +74,7 @@ This can either be `peregrine` or `spiritnet`.
 
 Hence, to start a collator node for the Spiritnet network, the parameter would be `--chain=spiritnet`.
 Unfortunately, there is no hardcoded chain spec for the Peregrine network, so the full path of the chainspec file must be provided `--chain=/node/dev-specs/kilt-parachain/peregrine-kilt.json`.
-Please refer to the [KILT node repository](https://github.com/KILTprotocol/kilt-node/blob/develop/chainspecs/peregrine/peregrine-paseo.json) or the [Docker image](https://hub.docker.com/r/kiltprotocol/kilt-node/tags) for more information.
+Please refer to the [KILT node repository](https://github.com/KILTprotocol/kilt-node/blob/master/dev-specs/kilt-parachain/peregrine-kilt.json) or the [Docker image](https://hub.docker.com/r/kiltprotocol/kilt-node/tags) for more information.
 
 ### Specify the Blockchain Storage Path
 


### PR DESCRIPTION
Docs should reflect what's already deployed. `develop` is subject to changes without too much thought, while `master` is supposed to check also on things like the docs. Hence all links should point to `master` to reflect the latest version of what's already released.